### PR TITLE
예약 등록 API 초기 모델 구현 

### DIFF
--- a/app/src/main/resources/application-local.yaml
+++ b/app/src/main/resources/application-local.yaml
@@ -7,7 +7,11 @@ spring:
     properties:
       dialect: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode : always
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:${DB_LOCAL_PORT}/${DB_LOCAL_DATABASE}?useSSL=false&useUnicode=true&allowPublicKeyRetrieval=true

--- a/app/src/main/resources/application-prod.yaml
+++ b/app/src/main/resources/application-prod.yaml
@@ -8,6 +8,10 @@ spring:
       dialect: org.hibernate.dialect.MySQL8Dialect
     hibernate:
       ddl-auto: update               # Dev/운영 스키마 보호
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: always
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${DB_PROD_HOST}:${DB_PROD_PORT}/${DB_PROD_DATABASE}?useSSL=false&useUnicode=true&allowPublicKeyRetrieval=true

--- a/app/src/main/resources/data.sql
+++ b/app/src/main/resources/data.sql
@@ -1,0 +1,8 @@
+INSERT INTO service_detail_type (id,service_detail_type,service_type)
+SELECT 1, '대청소','HOUSEKEEPING' WHERE NOT EXISTS (SELECT 1 FROM service_detail_type WHERE id = 1)
+UNION ALL
+SELECT 2, '부분청소','HOUSEKEEPING' WHERE NOT EXISTS (SELECT 1 FROM service_detail_type WHERE id = 2)
+UNION ALL
+SELECT 3, '아이돌봄','CARE' WHERE NOT EXISTS (SELECT 1 FROM service_detail_type WHERE id = 3)
+UNION ALL
+SELECT 4, '어르신돌봄','CARE' WHERE NOT EXISTS (SELECT 1 FROM service_detail_type WHERE id = 4);

--- a/app/src/main/resources/data.sql
+++ b/app/src/main/resources/data.sql
@@ -1,8 +1,10 @@
-INSERT INTO service_detail_type (id,service_detail_type,service_type)
-SELECT 1, '대청소','HOUSEKEEPING' WHERE NOT EXISTS (SELECT 1 FROM service_detail_type WHERE id = 1)
+INSERT INTO service_detail_type (id,service_detail_type,service_type,service_price)
+SELECT 1, '대청소','HOUSEKEEPING', 50000 WHERE NOT EXISTS (SELECT 1 FROM service_detail_type WHERE id = 1)
 UNION ALL
-SELECT 2, '부분청소','HOUSEKEEPING' WHERE NOT EXISTS (SELECT 1 FROM service_detail_type WHERE id = 2)
+SELECT 2, '부분청소','HOUSEKEEPING', 30000 WHERE NOT EXISTS (SELECT 1 FROM service_detail_type WHERE id = 2)
 UNION ALL
-SELECT 3, '아이돌봄','CARE' WHERE NOT EXISTS (SELECT 1 FROM service_detail_type WHERE id = 3)
+SELECT 3, '기타청소','HOUSEKEEPING', 20000 WHERE NOT EXISTS (SELECT 1 FROM service_detail_type WHERE id = 3)
 UNION ALL
-SELECT 4, '어르신돌봄','CARE' WHERE NOT EXISTS (SELECT 1 FROM service_detail_type WHERE id = 4);
+SELECT 4, '아이돌봄','CARE', 50000 WHERE NOT EXISTS (SELECT 1 FROM service_detail_type WHERE id = 4)
+UNION ALL
+SELECT 5, '어르신돌봄','CARE', 30000 WHERE NOT EXISTS (SELECT 1 FROM service_detail_type WHERE id = 5);

--- a/reservation/build.gradle
+++ b/reservation/build.gradle
@@ -20,7 +20,13 @@ repositories {
 dependencies {
     implementation project(':common')
 
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework:spring-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/reservation/src/main/java/kernel/maidlab/reservation/controller/ReservationApi.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/controller/ReservationApi.java
@@ -1,0 +1,29 @@
+package kernel.maidlab.reservation.controller;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kernel.maidlab.common.dto.ResponseDto;
+import kernel.maidlab.reservation.dto.response.AvailableManagerDto;
+
+@Tag(name= "Reservation", description = "예약 관련 API")
+public interface ReservationApi {
+	@Operation(
+		summary = "예약 가능 매니저 리스트 조회",
+		description = "예약 가능한 시간에 겹치는 일정이 없는 매니저들을 조회합니다.",
+		security = @SecurityRequirement(name = "JWT")
+	)
+	@ApiResponse(responseCode = "200", description = "조회 성공")
+	ResponseEntity<ResponseDto<List<AvailableManagerDto>>> getAvailableManagers(
+		@Parameter(description = "예약 시작 시간 (yyyy-MM-ddTHH:mm)", required = true)
+		@RequestParam("startTime") LocalDateTime startTime
+	);
+}

--- a/reservation/src/main/java/kernel/maidlab/reservation/controller/ReservationApi.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/controller/ReservationApi.java
@@ -1,29 +1,27 @@
 package kernel.maidlab.reservation.controller;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestParam;
-
+import org.springframework.web.bind.annotation.RequestBody;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import kernel.maidlab.common.dto.ResponseDto;
-import kernel.maidlab.reservation.dto.response.AvailableManagerDto;
+import kernel.maidlab.reservation.dto.request.PaymentRequestDto;
 
 @Tag(name= "Reservation", description = "예약 관련 API")
 public interface ReservationApi {
+
 	@Operation(
-		summary = "예약 가능 매니저 리스트 조회",
-		description = "예약 가능한 시간에 겹치는 일정이 없는 매니저들을 조회합니다.",
+		summary = "예약 결제 요청",
+		description = "예약 정보를 받아 예약 테이블을 생성합니다.",
 		security = @SecurityRequirement(name = "JWT")
 	)
-	@ApiResponse(responseCode = "200", description = "조회 성공")
-	ResponseEntity<ResponseDto<List<AvailableManagerDto>>> getAvailableManagers(
-		@Parameter(description = "예약 시작 시간 (yyyy-MM-ddTHH:mm)", required = true)
-		@RequestParam("startTime") LocalDateTime startTime
-	);
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "401", description = "비로그인 접속"),
+		@ApiResponse(responseCode = "403", description = "권한 없음"),
+		@ApiResponse(responseCode = "500", description = "데이터베이스 오류"),
+	})
+	ResponseEntity<Void> create(@RequestBody PaymentRequestDto dto);
 }

--- a/reservation/src/main/java/kernel/maidlab/reservation/controller/ReservationController.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/controller/ReservationController.java
@@ -1,0 +1,47 @@
+package kernel.maidlab.reservation.controller;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import kernel.maidlab.common.dto.ResponseDto;
+import kernel.maidlab.common.dto.ResponseType;
+import kernel.maidlab.common.dto.baseResponse.BaseResponse;
+import kernel.maidlab.common.dto.baseResponse.ResponseCode;
+import kernel.maidlab.reservation.dto.response.AvailableManagerDto;
+import kernel.maidlab.reservation.service.ReservationService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reservation")
+public class ReservationController implements ReservationApi{
+	private final ReservationService reservationService;
+
+	@Override
+	@GetMapping("/managers")
+	public ResponseEntity<ResponseDto<List<AvailableManagerDto>>> getAvailableManagers(
+		@RequestParam LocalDateTime startTime
+	) {
+		List<AvailableManagerDto> availableManagerList = reservationService.getAvailableManagersList(startTime);
+		return ResponseDto.success(ResponseType.SUCCESS,availableManagerList);
+	}
+}
+
+//
+// public ResponseEntity<BaseResponse<ManagerProfile>> getProfile(@RequestHeader("Authorization") String authHeader) {
+// 	String phone = jwtUtil.getPhoneFromToken(authHeader.replace("Bearer ", ""));
+//
+// 	if ("010-1111-1111".equals(phone)) {
+// 		ManagerProfile mockProfile = new ManagerProfile("홍길동", "강남구");
+// 		return ResponseEntity.ok(BaseResponse.success(mockProfile));
+// 	}
+//
+// 	return ResponseEntity.ok(BaseResponse.error(ResponseCode.AF));
+// }

--- a/reservation/src/main/java/kernel/maidlab/reservation/controller/ReservationController.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/controller/ReservationController.java
@@ -1,47 +1,29 @@
 package kernel.maidlab.reservation.controller;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import kernel.maidlab.common.dto.ResponseDto;
-import kernel.maidlab.common.dto.ResponseType;
-import kernel.maidlab.common.dto.baseResponse.BaseResponse;
-import kernel.maidlab.common.dto.baseResponse.ResponseCode;
-import kernel.maidlab.reservation.dto.response.AvailableManagerDto;
+import kernel.maidlab.reservation.dto.request.PaymentRequestDto;
 import kernel.maidlab.reservation.service.ReservationService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/reservation")
-public class ReservationController implements ReservationApi{
+public class ReservationController implements ReservationApi {
 	private final ReservationService reservationService;
 
 	@Override
-	@GetMapping("/managers")
-	public ResponseEntity<ResponseDto<List<AvailableManagerDto>>> getAvailableManagers(
-		@RequestParam LocalDateTime startTime
+	@PostMapping
+	public ResponseEntity<Void> create(
+		@RequestBody PaymentRequestDto dto
 	) {
-		List<AvailableManagerDto> availableManagerList = reservationService.getAvailableManagersList(startTime);
-		return ResponseDto.success(ResponseType.SUCCESS,availableManagerList);
+		reservationService.createReservation(dto);
+		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
-}
 
-//
-// public ResponseEntity<BaseResponse<ManagerProfile>> getProfile(@RequestHeader("Authorization") String authHeader) {
-// 	String phone = jwtUtil.getPhoneFromToken(authHeader.replace("Bearer ", ""));
-//
-// 	if ("010-1111-1111".equals(phone)) {
-// 		ManagerProfile mockProfile = new ManagerProfile("홍길동", "강남구");
-// 		return ResponseEntity.ok(BaseResponse.success(mockProfile));
-// 	}
-//
-// 	return ResponseEntity.ok(BaseResponse.error(ResponseCode.AF));
-// }
+}

--- a/reservation/src/main/java/kernel/maidlab/reservation/dto/request/PaymentRequestDto.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/dto/request/PaymentRequestDto.java
@@ -1,0 +1,39 @@
+package kernel.maidlab.reservation.dto.request;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PaymentRequestDto {
+	private Long serviceDetailTypeId; // ex) 0 : 대청소,가사
+
+	private String address;
+	private String addressDetail;
+
+	private Long MatchManagerId;
+
+	private Long consumerId;
+
+	private String housingType;
+	private Integer roomSize;
+	private String housingInformation;
+
+	private LocalDateTime reservationDate;
+	private LocalDateTime startTime;
+	private LocalDateTime endTime;
+
+	private String serviceAdd;
+	private Boolean helper;
+	private String pet;
+
+	private String specialRequest;
+
+	private Long totalPrice;
+
+}

--- a/reservation/src/main/java/kernel/maidlab/reservation/dto/response/AvailableManagerDto.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/dto/response/AvailableManagerDto.java
@@ -1,8 +1,5 @@
 package kernel.maidlab.reservation.dto.response;
 
-import java.util.List;
-
-import kernel.maidlab.reservation.enums.AdditionalService;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/reservation/src/main/java/kernel/maidlab/reservation/dto/response/AvailableManagerDto.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/dto/response/AvailableManagerDto.java
@@ -1,0 +1,20 @@
+package kernel.maidlab.reservation.dto.response;
+
+import java.util.List;
+
+import kernel.maidlab.reservation.enums.AdditionalService;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AvailableManagerDto {
+	private Long managerId;
+	private String managerName;
+	private String managerProfileImageUrl;
+	private Integer managerRating;
+	private String introduceText;
+	// private List<AdditionalService> additionalServiceList;
+}

--- a/reservation/src/main/java/kernel/maidlab/reservation/entity/Reservation.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/entity/Reservation.java
@@ -1,0 +1,88 @@
+package kernel.maidlab.reservation.entity;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import kernel.maidlab.reservation.enums.AdditionalService;
+import kernel.maidlab.reservation.enums.ReservationStatus;
+import kernel.maidlab.reservation.enums.ServiceType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "reservation")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Reservation {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private Long managerId;
+
+	@Column(nullable = false)
+	private Long consumerId;
+
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private ServiceType serviceType;
+
+	@Column(nullable = false)
+	private LocalDateTime reservationDate;
+	@Column(nullable = false)
+	private LocalDateTime startTime;
+	@Column(nullable = false)
+	private LocalDateTime endTime;
+
+	@Column(length=1000, nullable = false)
+	private String address;
+	@Column(length=1000)
+	private String addressDetail;
+	@Column(nullable = false)
+	private String housingType;
+	@Column(nullable = false)
+	private Integer roomSize;
+	@Column(nullable = false)
+	private Integer roomCount;
+
+	@Enumerated(EnumType.STRING)
+	private AdditionalService serviceAdd;
+
+	private Boolean helper;
+	private Boolean pet;
+
+	@Column(columnDefinition = "TEXT")
+	private String specialRequest;
+
+	@Column(nullable = false)
+	private BigDecimal totalPrice;
+
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private ReservationStatus status;
+
+	private LocalDateTime canceledAt;
+	private LocalDateTime createdAt;
+	private LocalDateTime modifiedAt;
+
+	public void cancel(LocalDateTime canceledAt){
+		this.status = ReservationStatus.CANCELED;
+		this.canceledAt = canceledAt;
+	}
+
+
+
+}

--- a/reservation/src/main/java/kernel/maidlab/reservation/entity/Reservation.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/entity/Reservation.java
@@ -7,13 +7,14 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import kernel.maidlab.reservation.enums.AdditionalService;
 import kernel.maidlab.reservation.enums.ReservationStatus;
-import kernel.maidlab.reservation.enums.ServiceType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,14 +32,26 @@ public class Reservation {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	private Long managerId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "service_detail_type_id", nullable = false)
+	private ServiceDetailType serviceDetailType;
+
+	@Column(length = 1000, nullable = false)
+	private String address;
+	@Column(length = 1000)
+	private String addressDetail;
+
+	private Long MatchManagerId;
 
 	@Column(nullable = false)
 	private Long consumerId;
 
 	@Column(nullable = false)
-	@Enumerated(EnumType.STRING)
-	private ServiceType serviceType;
+	private String housingType;
+	@Column(nullable = false)
+	private Integer roomSize;
+	@Column(nullable = false)
+	private String housingInformation;
 
 	@Column(nullable = false)
 	private LocalDateTime reservationDate;
@@ -47,28 +60,16 @@ public class Reservation {
 	@Column(nullable = false)
 	private LocalDateTime endTime;
 
-	@Column(length=1000, nullable = false)
-	private String address;
-	@Column(length=1000)
-	private String addressDetail;
-	@Column(nullable = false)
-	private String housingType;
-	@Column(nullable = false)
-	private Integer roomSize;
-	@Column(nullable = false)
-	private Integer roomCount;
-
-	@Enumerated(EnumType.STRING)
-	private AdditionalService serviceAdd;
+	private String serviceAdd;
 
 	private Boolean helper;
-	private Boolean pet;
+	private String pet;
 
 	@Column(columnDefinition = "TEXT")
 	private String specialRequest;
 
 	@Column(nullable = false)
-	private BigDecimal totalPrice;
+	private Long totalPrice;
 
 	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
@@ -78,11 +79,9 @@ public class Reservation {
 	private LocalDateTime createdAt;
 	private LocalDateTime modifiedAt;
 
-	public void cancel(LocalDateTime canceledAt){
+	public void cancel(LocalDateTime canceledAt) {
 		this.status = ReservationStatus.CANCELED;
 		this.canceledAt = canceledAt;
 	}
-
-
 
 }

--- a/reservation/src/main/java/kernel/maidlab/reservation/entity/ServiceDetailType.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/entity/ServiceDetailType.java
@@ -1,0 +1,34 @@
+package kernel.maidlab.reservation.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import kernel.maidlab.reservation.enums.ServiceType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "service_detail_type")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ServiceDetailType {
+	@Id
+	private Long id;
+
+	@Column(nullable = false)
+	private String serviceDetailType;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private ServiceType serviceType;
+
+	@Column(nullable = false)
+	private Long servicePrice;
+}

--- a/reservation/src/main/java/kernel/maidlab/reservation/enums/AdditionalService.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/enums/AdditionalService.java
@@ -1,8 +1,0 @@
-package kernel.maidlab.reservation.enums;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-
-@Schema(description = "추가 서비스 유형", example = "COOKING")
-public enum AdditionalService {
-	COOKING, IRONING, PREPARE, CLEANING, TOOLS
-}

--- a/reservation/src/main/java/kernel/maidlab/reservation/enums/AdditionalService.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/enums/AdditionalService.java
@@ -1,0 +1,8 @@
+package kernel.maidlab.reservation.enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "추가 서비스 유형", example = "COOKING")
+public enum AdditionalService {
+	COOKING, IRONING, PREPARE, CLEANING, TOOLS
+}

--- a/reservation/src/main/java/kernel/maidlab/reservation/enums/ReservationStatus.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/enums/ReservationStatus.java
@@ -1,0 +1,8 @@
+package kernel.maidlab.reservation.enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "예약 상태 유형", example = "PENDING")
+public enum ReservationStatus {
+	PENDING, CONFIRM, CANCELED, COMPLETED
+}

--- a/reservation/src/main/java/kernel/maidlab/reservation/enums/ServiceType.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/enums/ServiceType.java
@@ -4,5 +4,5 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "서비스 유형", example = "HOUSEKEEPING")
 public enum ServiceType {
-	HOUSEKEEPING, CLEANING // 가사, 청소
+	HOUSEKEEPING, CLEANING, CARE // 가사, 청소, 돌봄
 }

--- a/reservation/src/main/java/kernel/maidlab/reservation/enums/ServiceType.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/enums/ServiceType.java
@@ -1,0 +1,8 @@
+package kernel.maidlab.reservation.enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "서비스 유형", example = "HOUSEKEEPING")
+public enum ServiceType {
+	HOUSEKEEPING, CLEANING // 가사, 청소
+}

--- a/reservation/src/main/java/kernel/maidlab/reservation/repository/ReservationRepository.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/repository/ReservationRepository.java
@@ -1,16 +1,13 @@
 package kernel.maidlab.reservation.repository;
-import java.time.LocalDateTime;
-import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import kernel.maidlab.reservation.entity.Reservation;
-import kernel.maidlab.reservation.enums.ReservationStatus;
 
-public interface ReservationRepository extends JpaRepository<Reservation,Long>{
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
-	List<Reservation> findByConsumerId(Long consumerId);
-	List<Reservation> findByManagerId(Long managerId);
-	List<Reservation> findByReservationDateBetween(LocalDateTime start, LocalDateTime end);
-	List<Reservation> findByStatus(ReservationStatus status);
+	// List<Reservation> findByConsumerId(Long consumerId);
+	// List<Reservation> findByMatchManagerId(Long managerId);
+	// List<Reservation> findByReservationDateBetween(LocalDateTime start, LocalDateTime end);
+	// List<Reservation> findByStatus(ReservationStatus status);
 }

--- a/reservation/src/main/java/kernel/maidlab/reservation/repository/ReservationRepository.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/repository/ReservationRepository.java
@@ -1,0 +1,16 @@
+package kernel.maidlab.reservation.repository;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kernel.maidlab.reservation.entity.Reservation;
+import kernel.maidlab.reservation.enums.ReservationStatus;
+
+public interface ReservationRepository extends JpaRepository<Reservation,Long>{
+
+	List<Reservation> findByConsumerId(Long consumerId);
+	List<Reservation> findByManagerId(Long managerId);
+	List<Reservation> findByReservationDateBetween(LocalDateTime start, LocalDateTime end);
+	List<Reservation> findByStatus(ReservationStatus status);
+}

--- a/reservation/src/main/java/kernel/maidlab/reservation/repository/ServiceDetailTypeRepository.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/repository/ServiceDetailTypeRepository.java
@@ -1,0 +1,12 @@
+package kernel.maidlab.reservation.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kernel.maidlab.reservation.entity.ServiceDetailType;
+import kernel.maidlab.reservation.enums.ServiceType;
+
+public interface ServiceDetailTypeRepository extends JpaRepository<ServiceDetailType, Long> {
+	List<ServiceDetailType> findByServiceType(ServiceType type);
+}

--- a/reservation/src/main/java/kernel/maidlab/reservation/service/ReservationService.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/service/ReservationService.java
@@ -1,10 +1,9 @@
 package kernel.maidlab.reservation.service;
 
-import java.time.LocalDateTime;
-import java.util.List;
 
-import kernel.maidlab.reservation.dto.response.AvailableManagerDto;
+import kernel.maidlab.reservation.dto.request.PaymentRequestDto;
 
 public interface ReservationService {
-	List<AvailableManagerDto> getAvailableManagersList(LocalDateTime startTime);
+	// List<AvailableManagerDto> getAvailableManagersList(LocalDateTime startTime);
+	void createReservation(PaymentRequestDto dto);
 }

--- a/reservation/src/main/java/kernel/maidlab/reservation/service/ReservationService.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/service/ReservationService.java
@@ -1,0 +1,10 @@
+package kernel.maidlab.reservation.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import kernel.maidlab.reservation.dto.response.AvailableManagerDto;
+
+public interface ReservationService {
+	List<AvailableManagerDto> getAvailableManagersList(LocalDateTime startTime);
+}

--- a/reservation/src/main/java/kernel/maidlab/reservation/service/ReservationServiceImpl.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/service/ReservationServiceImpl.java
@@ -1,0 +1,25 @@
+package kernel.maidlab.reservation.service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import kernel.maidlab.reservation.dto.response.AvailableManagerDto;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationServiceImpl implements ReservationService {
+	@Override
+	public List<AvailableManagerDto> getAvailableManagersList(
+		LocalDateTime startTime
+	){
+		AvailableManagerDto mockManager = new AvailableManagerDto( 1L,"홍길동", "강남구",4,"야야야");
+		System.out.println(startTime);
+		List<AvailableManagerDto> availableMangerList = new ArrayList<>();
+		availableMangerList.add(mockManager);
+		return availableMangerList;
+	}
+}

--- a/reservation/src/main/java/kernel/maidlab/reservation/service/ReservationServiceImpl.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/service/ReservationServiceImpl.java
@@ -1,25 +1,72 @@
 package kernel.maidlab.reservation.service;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.springframework.stereotype.Service;
 
-import kernel.maidlab.reservation.dto.response.AvailableManagerDto;
+import kernel.maidlab.reservation.dto.request.PaymentRequestDto;
+import kernel.maidlab.reservation.entity.Reservation;
+import kernel.maidlab.reservation.entity.ServiceDetailType;
+import kernel.maidlab.reservation.enums.ReservationStatus;
+import kernel.maidlab.reservation.repository.ReservationRepository;
+import kernel.maidlab.reservation.repository.ServiceDetailTypeRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ReservationServiceImpl implements ReservationService {
+	private final ReservationRepository reservationRepository;
+	private final ServiceDetailTypeRepository serviceDetailTypeRepository;
+
 	@Override
-	public List<AvailableManagerDto> getAvailableManagersList(
-		LocalDateTime startTime
-	){
-		AvailableManagerDto mockManager = new AvailableManagerDto( 1L,"홍길동", "강남구",4,"야야야");
-		System.out.println(startTime);
-		List<AvailableManagerDto> availableMangerList = new ArrayList<>();
-		availableMangerList.add(mockManager);
-		return availableMangerList;
+	public void createReservation(PaymentRequestDto dto) {
+		ServiceDetailType detailType = serviceDetailTypeRepository.findById(dto.getServiceDetailTypeId())
+			.orElseThrow(() -> new IllegalArgumentException("유효하지않은 서비스 상세 타입입니다."));
+
+		// 서버에서 총 결제 금액 재계산
+		Long basePrice = detailType.getServicePrice();
+		Long additionalPrice = calculateAdditionalServicePrice(dto);
+		Long totalCalculatedPrice = basePrice + additionalPrice;
+		Long clientPrice = dto.getTotalPrice();
+
+		// 금액 비교
+		if (!totalCalculatedPrice.equals(clientPrice)) {
+			log.warn("결제 금액 불일치: client={}, server={}, detailTypeId={}", clientPrice, totalCalculatedPrice, dto.getServiceDetailTypeId());
+			throw new IllegalArgumentException("총 결제 금액이 일치하지 않습니다.");
+		}
+
+
+		Reservation reservation = Reservation.builder()
+			.serviceDetailType(detailType)
+			.address(dto.getAddress())
+			.addressDetail(dto.getAddressDetail())
+			.MatchManagerId(dto.getMatchManagerId())
+			.consumerId(dto.getConsumerId())
+			.housingType(dto.getHousingType())
+			.roomSize(dto.getRoomSize())
+			.housingInformation(dto.getHousingInformation())
+			.reservationDate(dto.getReservationDate())
+			.startTime(dto.getStartTime())
+			.endTime(dto.getEndTime())
+			.serviceAdd(dto.getServiceAdd())
+			.helper(dto.getHelper())
+			.pet(dto.getPet())
+			.specialRequest(dto.getSpecialRequest())
+			.totalPrice(clientPrice)
+			.status(ReservationStatus.PENDING)
+			.createdAt(LocalDateTime.now())
+			.build();
+		reservationRepository.save(reservation);
+	}
+
+	private Long calculateAdditionalServicePrice(PaymentRequestDto dto){
+		long additional = 0L;
+
+		if (dto.getServiceAdd() != null && dto.getServiceAdd().equals("COOK")) {
+			additional += 10_000;
+		}
+		return additional;
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#14 

## 📝작업 내용
- 예약(reservation) 도메인 controller, service 인터페이스, 구현체 분리 
- 예약 등록 초기 모델 구현 (간단하게 가격검증, 추후에 정확한 로직 구현)
- 서비스 상세 유형(대청소, 부분청소 등)의 가격 및 유형들 테이블 등록 및 기본 데이터 등록(INSERT) 

### 스크린샷 (선택)




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
