### PR TITLE
[feature/be/#14] 결제 -> 예약 테이블 생성 api

### DIFF
--- a/app/src/main/resources/application-local.yaml
+++ b/app/src/main/resources/application-local.yaml
@@ -19,3 +19,11 @@ spring:
     password: ${DB_LOCAL_PASSWORD}
 
 
+aws:
+  region: ap-northeast-2 #asia/seoul
+  s3:
+    bucket: maidlab-bucket
+    access-key: ${AWS_S3_ACCESSKEY}
+    secret-key: ${AWS_S3_SECRETKEY}
+
+

--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -5,5 +5,5 @@ spring:
     group:
       local: "local,localkey,swagger"
       prod: "prod, localkey, swagger"
-    active: local
+    active: prod
 

--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -5,5 +5,5 @@ spring:
     group:
       local: "local,localkey,swagger"
       prod: "prod, localkey, swagger"
-    active: prod
+    active: local
 

--- a/reservation/src/main/java/kernel/maidlab/reservation/controller/ReservationApi.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/controller/ReservationApi.java
@@ -8,21 +8,36 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import kernel.maidlab.reservation.dto.request.PaymentRequestDto;
+import kernel.maidlab.common.dto.ResponseDto;
+import kernel.maidlab.reservation.dto.request.ReservationRequestDto;
 
 @Tag(name = "Reservation", description = "예약 관련 API")
 public interface ReservationApi {
 
 	@Operation(
-		summary = "예약 결제 요청",
+		summary = "예약 테이블 생성",
 		description = "예약 정보를 받아 예약 테이블을 생성합니다.",
 		security = @SecurityRequirement(name = "JWT")
 	)
 	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "200", description = "테이블 생성 성공"),
 		@ApiResponse(responseCode = "401", description = "비로그인 접속"),
 		@ApiResponse(responseCode = "403", description = "권한 없음"),
 		@ApiResponse(responseCode = "500", description = "데이터베이스 오류"),
 	})
-	ResponseEntity<Void> create(@RequestBody PaymentRequestDto dto);
+	ResponseEntity<ResponseDto<String>> create(@RequestBody ReservationRequestDto dto);
+
+	@Operation(
+		summary = "예약 결제 요청",
+		description = "총 결제 금액이 맞는지 확인합니다.",
+		security = @SecurityRequirement(name = "JWT")
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "올바른 금액입니다."),
+		@ApiResponse(responseCode = "400", description = "요금이 다릅니다."),
+		@ApiResponse(responseCode = "401", description = "비로그인 접속"),
+		@ApiResponse(responseCode = "403", description = "권한 없음"),
+		@ApiResponse(responseCode = "500", description = "데이터베이스 오류"),
+	})
+	ResponseEntity<ResponseDto<String>> checkPrice(@RequestBody ReservationRequestDto dto);
 }

--- a/reservation/src/main/java/kernel/maidlab/reservation/controller/ReservationController.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/controller/ReservationController.java
@@ -1,29 +1,41 @@
 package kernel.maidlab.reservation.controller;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import kernel.maidlab.reservation.dto.request.PaymentRequestDto;
+import kernel.maidlab.common.dto.ResponseDto;
+import kernel.maidlab.common.dto.ResponseType;
+import kernel.maidlab.reservation.dto.request.ReservationRequestDto;
 import kernel.maidlab.reservation.service.ReservationService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/reservation")
+@RequestMapping("/api/reservations")
 public class ReservationController implements ReservationApi {
 	private final ReservationService reservationService;
 
 	@Override
-	@PostMapping
-	public ResponseEntity<Void> create(
-		@RequestBody PaymentRequestDto dto
+	@PostMapping("/match")
+	public ResponseEntity<ResponseDto<String>> create(
+		@RequestBody ReservationRequestDto dto
 	) {
 		reservationService.createReservation(dto);
-		return ResponseEntity.status(HttpStatus.CREATED).build();
+		String response = "예약 등록이 완료되었습니다.";
+		return ResponseDto.success(ResponseType.SUCCESS, response);
+	}
+
+	@Override
+	@PostMapping("/price")
+	public ResponseEntity<ResponseDto<String>> checkPrice(
+		@RequestBody ReservationRequestDto dto
+	) {
+		reservationService.checkTotalPrice(dto);
+		String response = "가격이 맞습니다.";
+		return ResponseDto.success(ResponseType.SUCCESS, response);
 	}
 
 }

--- a/reservation/src/main/java/kernel/maidlab/reservation/dto/request/ReservationRequestDto.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/dto/request/ReservationRequestDto.java
@@ -1,6 +1,5 @@
 package kernel.maidlab.reservation.dto.request;
 
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 import lombok.AllArgsConstructor;
@@ -10,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class PaymentRequestDto {
+public class ReservationRequestDto {
 	private Long serviceDetailTypeId; // ex) 0 : 대청소,가사
 
 	private String address;
@@ -29,11 +28,9 @@ public class PaymentRequestDto {
 	private LocalDateTime endTime;
 
 	private String serviceAdd;
-	private Boolean helper;
 	private String pet;
 
 	private String specialRequest;
 
 	private Long totalPrice;
-
 }

--- a/reservation/src/main/java/kernel/maidlab/reservation/service/ReservationService.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/service/ReservationService.java
@@ -5,6 +5,7 @@ import kernel.maidlab.reservation.dto.request.ReservationRequestDto;
 public interface ReservationService {
 	// List<AvailableManagerDto> getAvailableManagersList(LocalDateTime startTime);
 	void createReservation(ReservationRequestDto dto);
+
 	void checkTotalPrice(ReservationRequestDto dto);
 }
 

--- a/reservation/src/main/java/kernel/maidlab/reservation/service/ReservationService.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/service/ReservationService.java
@@ -1,8 +1,10 @@
 package kernel.maidlab.reservation.service;
 
-import kernel.maidlab.reservation.dto.request.PaymentRequestDto;
+import kernel.maidlab.reservation.dto.request.ReservationRequestDto;
 
 public interface ReservationService {
 	// List<AvailableManagerDto> getAvailableManagersList(LocalDateTime startTime);
-	void createReservation(PaymentRequestDto dto);
+	void createReservation(ReservationRequestDto dto);
+	void checkTotalPrice(ReservationRequestDto dto);
 }
+

--- a/reservation/src/main/java/kernel/maidlab/reservation/service/ReservationServiceImpl.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/service/ReservationServiceImpl.java
@@ -4,7 +4,8 @@ import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Service;
 
-import kernel.maidlab.reservation.dto.request.PaymentRequestDto;
+import jakarta.transaction.Transactional;
+import kernel.maidlab.reservation.dto.request.ReservationRequestDto;
 import kernel.maidlab.reservation.entity.Reservation;
 import kernel.maidlab.reservation.entity.ServiceDetailType;
 import kernel.maidlab.reservation.enums.ReservationStatus;
@@ -21,22 +22,30 @@ public class ReservationServiceImpl implements ReservationService {
 	private final ServiceDetailTypeRepository serviceDetailTypeRepository;
 
 	@Override
-	public void createReservation(PaymentRequestDto dto) {
+	public void checkTotalPrice(ReservationRequestDto dto) {
 		ServiceDetailType detailType = serviceDetailTypeRepository.findById(dto.getServiceDetailTypeId())
 			.orElseThrow(() -> new IllegalArgumentException("유효하지않은 서비스 상세 타입입니다."));
-
-		// 서버에서 총 결제 금액 재계산
-		Long basePrice = detailType.getServicePrice();
-		Long additionalPrice = calculateAdditionalServicePrice(dto);
-		Long totalCalculatedPrice = basePrice + additionalPrice;
-		Long clientPrice = dto.getTotalPrice();
-
-		// 금액 비교
-		if (!totalCalculatedPrice.equals(clientPrice)) {
-			log.warn("결제 금액 불일치: client={}, server={}, detailTypeId={}", clientPrice, totalCalculatedPrice,
-				dto.getServiceDetailTypeId());
+		Long serverCalculatedPrice = calculateTotalPrice(dto, detailType.getServicePrice());
+		if (!serverCalculatedPrice.equals(dto.getTotalPrice())) {
+			log.warn("금액 불일치 - client={}, server={}", dto.getTotalPrice(), serverCalculatedPrice);
 			throw new IllegalArgumentException("총 결제 금액이 일치하지 않습니다.");
 		}
+	}
+	@Transactional
+	@Override
+	public void createReservation(ReservationRequestDto dto) {
+		// 결제 검증 로직(애플리케이션 상용 전 true 고정)
+		boolean payValid = true;
+		if (!payValid){
+			throw new IllegalArgumentException("결제 검증 실패");
+		}
+
+		// 금액 재검증
+		checkTotalPrice(dto);
+
+		// 예약 저장
+		ServiceDetailType detailType = serviceDetailTypeRepository.findById(dto.getServiceDetailTypeId())
+			.orElseThrow(() -> new IllegalArgumentException("유효하지않은 서비스 상세 타입입니다."));
 
 		Reservation reservation = Reservation.builder()
 			.serviceDetailType(detailType)
@@ -51,22 +60,24 @@ public class ReservationServiceImpl implements ReservationService {
 			.startTime(dto.getStartTime())
 			.endTime(dto.getEndTime())
 			.serviceAdd(dto.getServiceAdd())
-			// .helper(dto.getHelper())
 			.pet(dto.getPet())
 			.specialRequest(dto.getSpecialRequest())
-			.totalPrice(clientPrice)
+			.totalPrice(dto.getTotalPrice())
 			.status(ReservationStatus.PENDING)
 			.createdAt(LocalDateTime.now())
 			.build();
 		reservationRepository.save(reservation);
 	}
 
-	private Long calculateAdditionalServicePrice(PaymentRequestDto dto) {
+
+
+	private Long calculateTotalPrice(ReservationRequestDto dto, Long basePrice) {
+
 		long additional = 0L;
 
 		if (dto.getServiceAdd() != null && dto.getServiceAdd().equals("COOK")) {
 			additional += 10_000;
 		}
-		return additional;
+		return basePrice+additional;
 	}
 }

--- a/reservation/src/main/java/kernel/maidlab/reservation/service/ReservationServiceImpl.java
+++ b/reservation/src/main/java/kernel/maidlab/reservation/service/ReservationServiceImpl.java
@@ -31,12 +31,13 @@ public class ReservationServiceImpl implements ReservationService {
 			throw new IllegalArgumentException("총 결제 금액이 일치하지 않습니다.");
 		}
 	}
+
 	@Transactional
 	@Override
 	public void createReservation(ReservationRequestDto dto) {
 		// 결제 검증 로직(애플리케이션 상용 전 true 고정)
 		boolean payValid = true;
-		if (!payValid){
+		if (!payValid) {
 			throw new IllegalArgumentException("결제 검증 실패");
 		}
 
@@ -69,8 +70,6 @@ public class ReservationServiceImpl implements ReservationService {
 		reservationRepository.save(reservation);
 	}
 
-
-
 	private Long calculateTotalPrice(ReservationRequestDto dto, Long basePrice) {
 
 		long additional = 0L;
@@ -78,6 +77,6 @@ public class ReservationServiceImpl implements ReservationService {
 		if (dto.getServiceAdd() != null && dto.getServiceAdd().equals("COOK")) {
 			additional += 10_000;
 		}
-		return basePrice+additional;
+		return basePrice + additional;
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#14 

## 📝작업 내용

- 결제 api -> 가격 비교 api 추가
- 예약 테이블에 @Transactional 추가로 결제 + 테이블 생성을 한 번에 트랜잭션 처리 

### 스크린샷 (선택)




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
