### PR TITLE
#56 feat:병합 해결 및 게시판 수정, 삭제 기능 추가 (사용자에 따른 기능은 아직 미완) 추가 pr 올릴 예정

### DIFF
--- a/api/src/main/java/kernel/maidlab/api/auth/entity/Consumer.java
+++ b/api/src/main/java/kernel/maidlab/api/auth/entity/Consumer.java
@@ -1,6 +1,7 @@
 package kernel.maidlab.api.auth.entity;
 
 import jakarta.persistence.*;
+import kernel.maidlab.api.board.common.UserBase;
 import kernel.maidlab.api.consumer.entity.ManagerPreference;
 import kernel.maidlab.common.entity.Base;
 import kernel.maidlab.common.enums.Gender;
@@ -23,7 +24,7 @@ import java.util.UUID;
 	@Index(name = "idx_consumer_phone_number", columnList = "phone_number", unique = true)})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Consumer extends Base {
+public class Consumer extends Base implements UserBase {
 
 	@Column(name = "uuid", nullable = false, unique = true)
 	private String uuid;

--- a/api/src/main/java/kernel/maidlab/api/auth/entity/Manager.java
+++ b/api/src/main/java/kernel/maidlab/api/auth/entity/Manager.java
@@ -1,6 +1,7 @@
 package kernel.maidlab.api.auth.entity;
 
 import jakarta.persistence.*;
+import kernel.maidlab.api.board.common.UserBase;
 import kernel.maidlab.common.entity.Base;
 import kernel.maidlab.common.enums.Gender;
 import kernel.maidlab.common.enums.Region;
@@ -25,7 +26,7 @@ import java.util.UUID;
 	@Index(name = "idx_manager_phone_number", columnList = "phone_number", unique = true)})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Manager extends Base {
+public class Manager extends Base implements UserBase {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/api/src/main/java/kernel/maidlab/api/board/common/UserBase.java
+++ b/api/src/main/java/kernel/maidlab/api/board/common/UserBase.java
@@ -1,0 +1,4 @@
+package kernel.maidlab.api.board.common;
+
+public interface UserBase {
+}

--- a/api/src/main/java/kernel/maidlab/api/board/controller/BoardController.java
+++ b/api/src/main/java/kernel/maidlab/api/board/controller/BoardController.java
@@ -1,7 +1,10 @@
 package kernel.maidlab.api.board.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
+
+
 import kernel.maidlab.api.board.dto.request.BoardRequestDto;
+import kernel.maidlab.api.board.dto.request.BoardUpdateRequestDto;
 import kernel.maidlab.api.board.dto.response.BoardDetailResponseDto;
 import kernel.maidlab.api.board.dto.response.BoardResponseDto;
 import kernel.maidlab.api.board.service.BoardService;
@@ -24,8 +27,9 @@ public class BoardController {
 
     // 수요자 게시판 글 생성
     @PostMapping
-    public ResponseEntity<ResponseDto<String>> createBoard(HttpServletRequest request,
-                                      @RequestBody BoardRequestDto boardRequestDto){
+    public ResponseEntity<ResponseDto<String>> createBoard(
+            HttpServletRequest request,
+            @RequestBody BoardRequestDto boardRequestDto){
         boardService.createConsumerBoard(request, boardRequestDto);
         return ResponseDto.success("게시글이 성공적으로 등록완료 되었습니다.");
     }
@@ -48,10 +52,26 @@ public class BoardController {
         return ResponseDto.success(consumerBoardDetailDto);
     }
 
+    // 게시판 글 수정
+    @PatchMapping("/{boardId}")
+    public ResponseEntity<ResponseDto<Object>> updateBoard(
+            HttpServletRequest request,
+            @PathVariable("boardId")Long boardId,
+            @RequestBody BoardUpdateRequestDto boardUpdateRequestDto
+    ){
+        boardService.modifyBoard(request, boardId, boardUpdateRequestDto);
+        return ResponseDto.success("게시글 수정이 완료되었습니다.");
+    }
 
-    // 답변 생성
+    //게시글 삭제
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<ResponseDto<Object>> deleteBoard(
+            HttpServletRequest request,
+            @PathVariable("boardId") Long boardId
+    ){
+        boardService.deleteBoard(request, boardId);
+        return ResponseDto.success("게시글이 삭제되었습니다.");
 
-    // 답변 수정
-
+    }
 
 }

--- a/api/src/main/java/kernel/maidlab/api/board/dto/BoardQueryDto.java
+++ b/api/src/main/java/kernel/maidlab/api/board/dto/BoardQueryDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class BoardQueryDto {
-//    b.answered, b.boardType, b.title, b.content, b.consumer.id
+
     private Long consumerId;
     private String title;
     private String content;

--- a/api/src/main/java/kernel/maidlab/api/board/dto/ImageDto.java
+++ b/api/src/main/java/kernel/maidlab/api/board/dto/ImageDto.java
@@ -10,13 +10,24 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ImageDto {
 
+    private Long id;
     private String imagePath;
     private String name;
 
     public static ImageDto from(Image image){
         return new ImageDto(
+                image.getId(),
                 image.getImagePath(),
                 image.getName()
         );
+    }
+
+    @Override
+    public String toString() {
+        return "ImageDto{" +
+                "id=" + id +
+                ", imagePath='" + imagePath + '\'' +
+                ", name='" + name + '\'' +
+                '}';
     }
 }

--- a/api/src/main/java/kernel/maidlab/api/board/dto/request/BoardRequestDto.java
+++ b/api/src/main/java/kernel/maidlab/api/board/dto/request/BoardRequestDto.java
@@ -13,4 +13,14 @@ public class BoardRequestDto {
     private String title;
     private String content;
     private List<ImageDto> images;
+
+    @Override
+    public String toString() {
+        return "ConsumerBoardRequestDto{" +
+                "boardType=" + boardType +
+                ", title='" + title + '\'' +
+                ", content='" + content + '\'' +
+                ", images=" + images +
+                '}';
+    }
 }

--- a/api/src/main/java/kernel/maidlab/api/board/dto/request/BoardUpdateRequestDto.java
+++ b/api/src/main/java/kernel/maidlab/api/board/dto/request/BoardUpdateRequestDto.java
@@ -1,0 +1,30 @@
+package kernel.maidlab.api.board.dto.request;
+
+import kernel.maidlab.api.board.dto.ImageDto;
+import kernel.maidlab.api.board.eum.BoardType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardUpdateRequestDto {
+
+    private String title;
+    private String content;
+    private BoardType boardType;
+    private List<ImageDto> images;
+
+    @Override
+    public String toString() {
+        return "BoardUpdateRequestDto{" +
+                "title='" + title + '\'' +
+                ", content='" + content + '\'' +
+                ", boardType=" + boardType +
+                ", images=" + images +
+                '}';
+    }
+}

--- a/api/src/main/java/kernel/maidlab/api/board/dto/response/BoardDetailResponseDto.java
+++ b/api/src/main/java/kernel/maidlab/api/board/dto/response/BoardDetailResponseDto.java
@@ -17,7 +17,7 @@ public class BoardDetailResponseDto {
 
     private String title;
     private String content;
-    private boolean answered;
+    private boolean isAnswered;
     private BoardType boardType;
 //    private LocalDateTime createAt
     private List<ImageDto> images;
@@ -29,12 +29,12 @@ public class BoardDetailResponseDto {
         return new BoardDetailResponseDto(
                 board.getTitle(),
                 board.getContent(),
-                board.isAnswered(),
+                board.getIsAnswered(),
                 board.getBoardType(),
                 images.stream()
                         .map(ImageDto::from)
                         .toList(),
-                board.isAnswered() ? AnswerResponseDto.from(board.getAnswer()) : null
+                board.getIsAnswered() ? AnswerResponseDto.from(board.getAnswer()) : null
         );
     }
 

--- a/api/src/main/java/kernel/maidlab/api/board/dto/response/BoardResponseDto.java
+++ b/api/src/main/java/kernel/maidlab/api/board/dto/response/BoardResponseDto.java
@@ -13,7 +13,7 @@ public class BoardResponseDto {
 
     private String title;
     private String content;
-    private boolean answered;
+    private boolean isAnswered;
     private BoardType boardType;
     //createAt - Base엔티티 수정시 추가 예정
 
@@ -23,7 +23,7 @@ public class BoardResponseDto {
         BoardResponseDto boardDto = new BoardResponseDto();
         boardDto.title = boardQueryDto.getTitle();
         boardDto.content = boardQueryDto.getContent();
-        boardDto.answered = boardQueryDto.isAnswered();
+        boardDto.isAnswered = boardQueryDto.isAnswered();
         boardDto.boardType = boardQueryDto.getBoardType();
         return boardDto;
     }

--- a/api/src/main/java/kernel/maidlab/api/board/entity/Board.java
+++ b/api/src/main/java/kernel/maidlab/api/board/entity/Board.java
@@ -4,11 +4,13 @@ import jakarta.persistence.*;
 import kernel.maidlab.api.auth.entity.Consumer;
 import kernel.maidlab.api.auth.entity.Manager;
 import kernel.maidlab.api.board.dto.request.BoardRequestDto;
+import kernel.maidlab.api.board.dto.request.BoardUpdateRequestDto;
 import kernel.maidlab.common.entity.Base;
 import kernel.maidlab.api.board.eum.BoardType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Collections;
 import java.util.List;
 
 @Getter
@@ -27,8 +29,8 @@ public class Board extends Base {
    @OneToOne(mappedBy = "board", cascade = CascadeType.ALL)
     private Answer answer;
 
-    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<Image> imageList;
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Image> images;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -40,8 +42,23 @@ public class Board extends Base {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    @Column(nullable = false)
-    private boolean answered;
+    @Column(name = "is_answered", nullable = false)
+    private boolean isAnswered;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted;
+
+    public boolean getIsAnswered(){
+        return  isAnswered;
+    }
+
+    public boolean getIsDeleted(){
+        return isDeleted;
+    }
+
+    public void updateIsDelete(boolean isDeleted){
+        this.isDeleted = isDeleted;
+    }
 
     public Board(Consumer consumer, BoardType boardType, String title, String content) {
         this.consumer = consumer;
@@ -59,7 +76,17 @@ public class Board extends Base {
         );
     }
 
+    public List<Image> getImages() {
+        return images != null ? images : Collections.emptyList();
+    }
+
+    public void boardUpdate(BoardUpdateRequestDto dto) {
+        this.title = dto.getTitle();
+        this.content = dto.getContent();
+        this.boardType = dto.getBoardType();
+    }
+
     public void makeAnswer() {
-        this.answered = true;
+        this.isAnswered = true;
     }
 }

--- a/api/src/main/java/kernel/maidlab/api/board/entity/Image.java
+++ b/api/src/main/java/kernel/maidlab/api/board/entity/Image.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import kernel.maidlab.api.board.dto.ImageDto;
 import kernel.maidlab.common.entity.Base;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,9 +20,18 @@ public class Image extends Base {
     @JoinColumn(name = "board_id")
     private Board board;
 
-    @Column(name = "image_url", nullable = false)
+    @Column(name = "image_path", nullable = false)
     private String imagePath;
 
     @Column(nullable = false)
     private String name;
+
+    public void changeBoard(Board board) {
+        this.board = board;
+    }
+
+    public void updateImage(ImageDto imageDto) {
+        this.name = imageDto.getName();
+        this.imagePath = imageDto.getImagePath();
+    }
 }

--- a/api/src/main/java/kernel/maidlab/api/board/repository/BoardRepository.java
+++ b/api/src/main/java/kernel/maidlab/api/board/repository/BoardRepository.java
@@ -14,8 +14,23 @@ import java.util.Optional;
 public interface BoardRepository extends JpaRepository<Board, Long>, BoardRepositoryCustom {
 
     // 나중에 쿼리dsl로 바꿀 예정
-    @Query("SELECT b FROM Board b LEFT JOIN FETCH b.answer a WHERE b.id = :boardId AND b.answered = true")
+    // todo: 나중에 쿼리dsl로 바꿀 예정
+    @Query("SELECT b, a " +
+            "FROM Board b " +
+            "LEFT JOIN FETCH b.answer a " +
+            "WHERE b.id = :boardId " +
+            "AND b.isAnswered = true " +
+            "AND b .isDeleted = false")
     Optional<Board> findBoardWithAnswerIfAnswered(@Param("boardId") Long boardId);
+
+    /**
+     * isDeleted = false만 조회하도록
+     */
+    // 전체 게시판 조회
+    List<Board> findAllByIsDeletedFalse();
+
+    // 단건 조회
+    Optional<Board> findByIdAndIsDeletedFalse(Long id);
 
 	List<BoardQueryDto> findAllByManagerIdNull(Pageable pageable);
 

--- a/api/src/main/java/kernel/maidlab/api/board/repository/BoardRepository.java
+++ b/api/src/main/java/kernel/maidlab/api/board/repository/BoardRepository.java
@@ -15,9 +15,9 @@ public interface BoardRepository extends JpaRepository<Board, Long>, BoardReposi
 
     // 나중에 쿼리dsl로 바꿀 예정
     // todo: 나중에 쿼리dsl로 바꿀 예정
-    @Query("SELECT b, a " +
+    @Query("SELECT b " +
             "FROM Board b " +
-            "LEFT JOIN FETCH b.answer a " +
+            "LEFT JOIN FETCH b.answer " +
             "WHERE b.id = :boardId " +
             "AND b.isAnswered = true " +
             "AND b .isDeleted = false")

--- a/api/src/main/java/kernel/maidlab/api/board/repository/BoardRepositoryCustom.java
+++ b/api/src/main/java/kernel/maidlab/api/board/repository/BoardRepositoryCustom.java
@@ -2,10 +2,11 @@ package kernel.maidlab.api.board.repository;
 
 import feign.Param;
 import kernel.maidlab.api.board.dto.BoardQueryDto;
+import kernel.maidlab.common.enums.UserType;
 
 import java.util.List;
 
 public interface BoardRepositoryCustom {
 
-    List<BoardQueryDto> findAllByConsumerUuid(@Param("uuid") String uuid);
+    List<BoardQueryDto> findAllByUserIdIsDeletedFalse(Long userId, UserType userType);
 }

--- a/api/src/main/java/kernel/maidlab/api/board/repository/BoardRepositoryCustomImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/board/repository/BoardRepositoryCustomImpl.java
@@ -1,9 +1,11 @@
 package kernel.maidlab.api.board.repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kernel.maidlab.api.board.dto.BoardQueryDto;
 import kernel.maidlab.api.board.dto.QBoardQueryDto;
 import kernel.maidlab.api.board.entity.QBoard;
+import kernel.maidlab.common.enums.UserType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -16,19 +18,25 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<BoardQueryDto> findAllByConsumerUuid(String uuid) {
+    public List<BoardQueryDto> findAllByUserIdIsDeletedFalse(Long userId, UserType userType) {
         QBoard board = QBoard.board;
+
+        BooleanExpression condition = (userType == UserType.CONSUMER)
+                ? board.consumer.id.eq(userId)
+                : board.manager.id.eq(userId);
+
+        BooleanExpression notDeleted = board.isDeleted.isFalse();
 
         return jpaQueryFactory
                 .select(new QBoardQueryDto(
-                        board.consumer.id,
+                        board.id,
                         board.title,
                         board.content,
                         board.boardType,
-                        board.answered
+                        board.isAnswered
                 ))
                 .from(board)
-                .where(board.consumer.uuid.eq(uuid))
+                .where(condition.and(notDeleted))
                 .fetch();
     }
 }

--- a/api/src/main/java/kernel/maidlab/api/board/repository/ImageRepository.java
+++ b/api/src/main/java/kernel/maidlab/api/board/repository/ImageRepository.java
@@ -1,11 +1,16 @@
 package kernel.maidlab.api.board.repository;
 
+import kernel.maidlab.api.board.entity.Board;
 import kernel.maidlab.api.board.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 
 import java.util.List;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
     List<Image> findAllByBoardId(Long boardId);
+
+    @Modifying
+    void deleteAllByBoard(Board board);
 }

--- a/api/src/main/java/kernel/maidlab/api/board/service/BoardService.java
+++ b/api/src/main/java/kernel/maidlab/api/board/service/BoardService.java
@@ -3,6 +3,7 @@ package kernel.maidlab.api.board.service;
 import jakarta.servlet.http.HttpServletRequest;
 import kernel.maidlab.api.board.dto.request.AnswerRequestDto;
 import kernel.maidlab.api.board.dto.request.BoardRequestDto;
+import kernel.maidlab.api.board.dto.request.BoardUpdateRequestDto;
 import kernel.maidlab.api.board.dto.response.BoardDetailResponseDto;
 import kernel.maidlab.api.board.dto.response.BoardResponseDto;
 
@@ -24,6 +25,10 @@ public interface BoardService {
     List<BoardResponseDto> getAllRefundBoardList(HttpServletRequest request, int page, int size);
 
     List<BoardResponseDto> getAllConsultationBoardList(HttpServletRequest request, int page, int size);
+
+    void modifyBoard(HttpServletRequest request, Long id, BoardUpdateRequestDto boardUpdateRequestDto);
+
+    void deleteBoard(HttpServletRequest request, Long boardId);
 
     void createAnswer(AnswerRequestDto requestDto, HttpServletRequest request, Long boardId);
 

--- a/api/src/main/java/kernel/maidlab/api/board/service/BoardServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/board/service/BoardServiceImpl.java
@@ -3,9 +3,14 @@ package kernel.maidlab.api.board.service;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import kernel.maidlab.api.auth.entity.Consumer;
+import kernel.maidlab.api.auth.entity.Manager;
+import kernel.maidlab.api.auth.jwt.JwtFilter;
+import kernel.maidlab.api.board.common.UserBase;
 import kernel.maidlab.api.board.dto.BoardQueryDto;
+import kernel.maidlab.api.board.dto.ImageDto;
 import kernel.maidlab.api.board.dto.request.AnswerRequestDto;
 import kernel.maidlab.api.board.dto.request.BoardRequestDto;
+import kernel.maidlab.api.board.dto.request.BoardUpdateRequestDto;
 import kernel.maidlab.api.board.dto.response.BoardDetailResponseDto;
 import kernel.maidlab.api.board.dto.response.BoardResponseDto;
 import kernel.maidlab.api.board.entity.Answer;
@@ -15,6 +20,7 @@ import kernel.maidlab.api.board.repository.AnswerRepository;
 import kernel.maidlab.api.board.repository.BoardRepository;
 import kernel.maidlab.api.board.repository.ImageRepository;
 import kernel.maidlab.api.util.AuthUtil;
+import kernel.maidlab.common.enums.UserType;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.PageRequest;
@@ -24,7 +30,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.file.AccessDeniedException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -35,42 +44,55 @@ public class BoardServiceImpl implements BoardService {
 	private final ImageRepository imageRepository;
 	private final AuthUtil authUtil;
     private final AnswerRepository answerRepository;
-	// 수요자 게시판 글 생성
-	public void createConsumerBoard(HttpServletRequest request,
-		BoardRequestDto boardRequestDto) {
 
+	// 게시판 글 생성
+	public void createConsumerBoard(
+			HttpServletRequest request,
+			BoardRequestDto boardRequestDto) {
+
+
+		// todo: 사용자에 따른 게시판 생성 로직 리팩토링 필요
+		// 현재 수요자 기준으로 게시핀이 생성됨
 		Consumer consumer = authUtil.getConsumer(request);
 		Board board = Board.createConsumerBoard(consumer, boardRequestDto);
 		boardRepository.save(board);
 
 		boardRequestDto.getImages()
-			.forEach((imageDto) -> imageRepository.save(
-				new Image(
-					board,
-					imageDto.getImagePath(),
-					imageDto.getName())));
+				.forEach((imageDto) -> imageRepository.save(
+						new Image(
+								board,
+								imageDto.getImagePath(),
+								imageDto.getName())));
 	}
 
-	// 수요자 게시글 전체 조회
+
+
+	// 게시글 전체 조회
 	@Transactional(readOnly = true)
 	public List<BoardResponseDto> getConsumerBoardList(HttpServletRequest request) {
 
-		String uuid = authUtil.getUuid(request);
-		List<BoardQueryDto> boardQueryDto = boardRepository.findAllByConsumerUuid(uuid);
+		Object user = request.getAttribute(JwtFilter.CURRENT_USER_KEY);
+		UserType userType = (UserType) request.getAttribute(JwtFilter.CURRENT_USER_TYPE_KEY);
 
-		return boardQueryDto.stream()
-			.map(BoardResponseDto::from)
-			.toList();
+		List<BoardQueryDto> boardQueryDtoList = getBoardQueryDtoList(user, userType);
+
+		return boardQueryDtoList.stream()
+				.map(BoardResponseDto::from)
+				.toList();
 	}
 
 	// 수요자 글 상세 조회
-	public BoardDetailResponseDto getConsumerBoard(HttpServletRequest request,
-												   Long boardId) throws AccessDeniedException {
+	@Transactional(readOnly = true)
+	public BoardDetailResponseDto getConsumerBoard(
+			HttpServletRequest request,
+			Long boardId
+	) throws AccessDeniedException {
 
+		// todo: 사용자에 따른 상세 접근 필요
 		// 검증 로직
 		Consumer consumer = authUtil.getConsumer(request);
-		Board board = boardRepository.findById(boardId)
-			.orElseThrow(() -> new EntityNotFoundException("존재하지 않는 게시물 입니다."));
+		Board board = boardRepository.findByIdAndIsDeletedFalse(boardId)
+				.orElseThrow(() -> new EntityNotFoundException("존재하지 않는 게시물 입니다."));
 
 		// 토큰으로 찾은 수요자id와 PathVariable로 넘어온 게시판id로 찾은 consumerId와 비교
 		if (!consumer.getId().equals(board.getConsumer().getId())) {
@@ -78,9 +100,9 @@ public class BoardServiceImpl implements BoardService {
 		}
 
 		// 답변여부가 true면 답변까지 조회
-		if (board.isAnswered()) {
+		if (board.getIsAnswered()) {
 			board = boardRepository.findBoardWithAnswerIfAnswered(boardId)
-				.orElseThrow(() -> new EntityNotFoundException("답변이 존재하지 않습니다."));
+					.orElseThrow(() -> new EntityNotFoundException("답변이 존재하지 않습니다."));
 		}
 
 		List<Image> images = imageRepository.findAllByBoardId(boardId);
@@ -88,6 +110,142 @@ public class BoardServiceImpl implements BoardService {
 		return BoardDetailResponseDto.from(board, images);
 
 	}
+
+	// 수정
+	public void modifyBoard(
+			HttpServletRequest request,
+			Long boardId,
+			BoardUpdateRequestDto boardUpdateRequestDto) {
+
+		Board board = boardRepository.findByIdAndIsDeletedFalse(boardId)
+				.orElseThrow(() -> new RuntimeException("게시글이 존재하지 않습니다."));
+
+		// 사용자 검증
+		UserBase user = getUser(request);
+		if (!isUserBoardWriter(board, user)) {
+			throw new RuntimeException("수정 권한이 없습니다.");
+		}
+
+		board.boardUpdate(boardUpdateRequestDto);
+
+		List<Image> currentImages = imageRepository.findAllByBoardId(boardId);
+		List<ImageDto> newImageDataList = boardUpdateRequestDto.getImages();
+
+		updateImages(currentImages, newImageDataList, board);
+
+	}
+
+	// 게시글 삭제
+	public void deleteBoard(
+			HttpServletRequest request,
+			Long boardId
+	){
+		Board board = boardRepository
+				.findByIdAndIsDeletedFalse(boardId)
+				.orElseThrow(() -> new EntityNotFoundException("존재하지 않는 게시판 입니다."));
+
+		board.updateIsDelete(true);
+	}
+
+	/**
+	 *서비스 외의 로직
+	 */
+	// 사용자 접근 검증
+	public boolean isUserBoardWriter(Board board, UserBase user) {
+		if (user instanceof Consumer consumer) {
+			return board.getConsumer() != null && board.getConsumer().getId().equals(consumer.getId());
+		} else if (user instanceof Manager manager) {
+			return board.getManager() != null && board.getManager().getId().equals(manager.getId());
+		}
+		return false;
+	}
+
+
+	// user타입에 따른 board 조회
+	public List<BoardQueryDto> getBoardQueryDtoList (Object user, UserType userType) {
+
+		if (userType == UserType.CONSUMER) {
+			Consumer consumer = (Consumer) user;
+			return boardRepository.findAllByUserIdIsDeletedFalse(consumer.getId(), userType);
+
+		} else if (userType == UserType.MANAGER) {
+			Manager manager = (Manager) user;
+			return boardRepository.findAllByUserIdIsDeletedFalse(manager.getId(), userType);
+
+		}
+		throw new IllegalArgumentException("유효하지 않은 사용자 타입입니다: " + userType);
+	}
+
+	// 유저 찾기
+	public UserBase getUser(HttpServletRequest request) {
+
+		UserType userType = (UserType) request.getAttribute(JwtFilter.CURRENT_USER_TYPE_KEY);
+		Object user = request.getAttribute(JwtFilter.CURRENT_USER_KEY);
+
+		return switch (userType.getName()){
+			case "회원" -> (Consumer) user;
+			case "매니저" -> (Manager) user;
+			default -> throw new IllegalArgumentException("유효하지 않은 사용자 유형 입니다.");
+		};
+	}
+
+
+	// 이미지 수정 로직
+	// todo:너무 많은 역할을 담담하고 있음 - 추후 리펙토링 필요
+	public void updateImages(List<Image> currentImages, List<ImageDto> newImageDataList, Board board) {
+
+		// 사용자가 images null을 보낸 경우 기존 이미지만 삭제후 리턴
+		if(newImageDataList == null){
+			imageRepository.deleteAllByBoard(board);
+			board.getImages().clear();
+			return;
+		}
+
+		// 현재 이미지 ID 목록
+		Set<Long> currentImageIds = currentImages.stream()
+				.map(Image::getId)
+				.collect(Collectors.toSet());
+
+		// 사용자가 보낸 ID들 중 유효하지 않은 ID 체크
+		List<Long> invalidIds = newImageDataList.stream()
+				.map(ImageDto::getId)
+				.filter(Objects::nonNull)
+				.filter(id -> !currentImageIds.contains(id))
+				.toList();
+
+		if (!invalidIds.isEmpty()) {
+			throw new IllegalArgumentException("잘못된 이미지 ID가 포함되어 있습니다: " + invalidIds);
+		}
+
+		// 삭제할 이미지: 현재 DB에 있으나 요청에서 누락된 것
+		Set<Long> newImageIds = newImageDataList.stream()
+				.map(ImageDto::getId)
+				.filter(Objects::nonNull)
+				.collect(Collectors.toSet());
+
+		List<Image> imagesToRemove = currentImages.stream()
+				.filter(img -> !newImageIds.contains(img.getId()))
+				.toList();
+
+		// 기존 이미지 업데이트
+		for (Image currentImage : currentImages) {
+			newImageDataList.stream()
+					.filter(dto -> dto.getId() != null && dto.getId().equals(currentImage.getId()))
+					.findFirst()
+					.ifPresent(currentImage::updateImage);
+		}
+
+		// 새 이미지 추가 (ID가 null인 것들)
+		for (ImageDto dto : newImageDataList) {
+			if (dto.getId() == null) {
+				Image newImage = new Image(board, dto.getName(), dto.getImagePath());
+				board.getImages().add(newImage); // 연관관계 추가
+			}
+		}
+		imageRepository.deleteAll(imagesToRemove);
+	}
+
+
 
 	@Override
 	public List<BoardResponseDto> getAllRefundBoardList(HttpServletRequest request, int page, int size) {

--- a/api/src/main/java/kernel/maidlab/api/config/FilterConfig.java
+++ b/api/src/main/java/kernel/maidlab/api/config/FilterConfig.java
@@ -17,7 +17,7 @@ public class FilterConfig {
 	public FilterRegistrationBean<Filter> jwtFilterRegistration(JwtFilter jwtFilter) {
 		FilterRegistrationBean<Filter> registration = new FilterRegistrationBean<>();
 		registration.setFilter(jwtFilter);
-		registration.addUrlPatterns("/api/auth/*", "/api/consumer/*", "/api/manager/*"); // 인증이 필요한 경로만 필터링
+		registration.addUrlPatterns("/api/auth/*", "/api/consumer/*", "/api/manager/*", "/api/board/*"); // 인증이 필요한 경로만 필터링
 		registration.setName("jwtFilter");
 		registration.setOrder(2);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #56 

## 📝작업 내용

> 게시판 수정 , 삭제 기능 추가

사용자 (consumer, manager) 에 따른 분류는 아직 못했습니다. 
수요자 기준으러 기능(생성, 조회, 수정, 삭제)은 잘 작동 합니다. 
사용자 따른 분류는 추가 pr 올리겠습니다.

### 스크린샷 (선택)




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
