### PR TITLE
refactor: S3 파일 업로드 비즈니스 로직 수정

### DIFF
--- a/common/src/main/java/kernel/maidlab/common/controller/S3Controller.java
+++ b/common/src/main/java/kernel/maidlab/common/controller/S3Controller.java
@@ -1,0 +1,35 @@
+package kernel.maidlab.common.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kernel.maidlab.common.dto.FileNamesRequestDto;
+import kernel.maidlab.common.dto.PresignedFileResponseDto;
+import kernel.maidlab.common.dto.ResponseDto;
+import kernel.maidlab.common.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/files")
+@RequiredArgsConstructor
+public class S3Controller {
+
+	private final S3Service s3Service;
+
+	@PostMapping("/presigned-urls")
+	public ResponseEntity<ResponseDto<List<PresignedFileResponseDto>>> getPresignedUrls(
+		@RequestBody FileNamesRequestDto request) {
+		List<PresignedFileResponseDto> presignedUrls = s3Service.uploadFile(
+			request.getFilenames(),
+			"uploads"
+		);
+		return ResponseDto.success(presignedUrls);
+	}
+}

--- a/common/src/main/java/kernel/maidlab/common/service/impl/S3ServiceImpl.java
+++ b/common/src/main/java/kernel/maidlab/common/service/impl/S3ServiceImpl.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service;
 import kernel.maidlab.common.dto.PresignedFileResponseDto;
 import kernel.maidlab.common.service.S3Service;
 import lombok.RequiredArgsConstructor;
-// import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
@@ -19,48 +18,48 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 @Service
 @RequiredArgsConstructor
 public class S3ServiceImpl implements S3Service {
-	// private final S3Client s3Client; 백엔드에서 파일 전송할 때 필요
 
 	private final S3Presigner s3Presigner;
 
 	@Value("${aws.s3.bucket}")
 	private String bucketName;
 
-	// 백엔드에서 직접 파일 보내는 함수
-	// public String uploadFile(String key, MultipartFile file) throws IOException {
-	// 	String filename = UUID.randomUUID() + "_" + file.getOriginalFilename();
-	//
-	// 	PutObjectRequest request = PutObjectRequest.builder()
-	// 		.bucket(bucketName)
-	// 		.key(key + filename)
-	// 		//.contentType(file.getContentType())
-	// 		.build();
-	//
-	// 	s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
-	//
-	// 	return filename;
-	// }
-
-	//presigned url 이용하여 전송하는 함수
 	@Override
 	public List<PresignedFileResponseDto> uploadFile(List<String> filenames, String prefix) {
 		return filenames.stream().map(filename -> {
-			String key = prefix + UUID.randomUUID() + "_" + filename;
+			String key = prefix + "/" + UUID.randomUUID() + "_" + filename;
+
+			String contentType = getContentType(filename);
 
 			PutObjectRequest objectRequest = PutObjectRequest.builder()
 				.bucket(bucketName)
 				.key(key)
-				.contentType("application/octet-stream")
+				.contentType(contentType)
 				.build();
 
 			PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
 				.putObjectRequest(objectRequest)
-				.signatureDuration(Duration.ofMinutes(10))
+				.signatureDuration(Duration.ofMinutes(15)) // 15분으로 증가
 				.build();
 
 			PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
 
 			return new PresignedFileResponseDto(key, presignedRequest.url().toString());
 		}).toList();
+	}
+
+	// 파일 확장자에 따른 Content-Type 결정
+	private String getContentType(String filename) {
+		String extension = filename.substring(filename.lastIndexOf(".") + 1).toLowerCase();
+
+		return switch (extension) {
+			case "jpg", "jpeg" -> "image/jpeg";
+			case "png" -> "image/png";
+			case "gif" -> "image/gif";
+			case "pdf" -> "application/pdf";
+			case "doc" -> "application/msword";
+			case "docx" -> "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+			default -> "application/octet-stream";
+		};
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #112

## 📝작업 내용

> s3 컨트롤러 만들어서 api로 사용
> 서비스 로직에 키값 변경 및 콘텐츠 타입 명시