### PR TITLE
refactor: BoardServiceImpl 게시판 수정시 이미지가 name, path 순서가 바뀌어 저장되는 문제 해결 #151 

### DIFF
--- a/api/src/main/java/kernel/maidlab/api/board/service/BoardServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/board/service/BoardServiceImpl.java
@@ -232,7 +232,7 @@ public class BoardServiceImpl implements BoardService {
 		// 새 이미지 추가 (ID가 null인 것들)
 		for (ImageDto dto : newImageDataList) {
 			if (dto.getId() == null) {
-				Image newImage = new Image(board, dto.getName(), dto.getImagePath());
+				Image newImage = new Image(board, dto.getImagePath(), dto.getName());
 				board.getImages().add(newImage); // 연관관계 추가
 			}
 		}


### PR DESCRIPTION
## #️⃣연관된 이슈

>  #151 

## 📝작업 내용

> 게시판 수정시 이미지를  불러오지 못하는 문제가 발생하여 문제 해결

원인 : 이미지 엔티티를 만드는 과정에서 생성자에 매개변수 순서기 뒤바뀌어서 발생한 문제

해결: 매개변수 위치를 올바르게 바꾸어 주었다. 

### 스크린샷 (선택)




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
