### PR TITLE
refactor: ConsumerController, ConsumerService 찜/블랙리스트 매니저 삭제 기능 수정

### DIFF
--- a/api/src/main/java/kernel/maidlab/api/consumer/repository/ManagerPreferenceRepository.java
+++ b/api/src/main/java/kernel/maidlab/api/consumer/repository/ManagerPreferenceRepository.java
@@ -21,7 +21,7 @@ public interface ManagerPreferenceRepository extends JpaRepository<ManagerPrefer
             "WHERE mp.consumer.id = :consumerId AND mp.preference = false ")
     List<Manager> findBlackListedManagers(@Param("consumerId") Long consumerId);
 
-    long deleteByConsumerIdAndManagerIdAndPreferenceIsTrue(Long consumerId, Long managerId);
+    long deleteByConsumerIdAndManagerId(Long consumerId, Long managerId);
 
 
 }

--- a/api/src/main/java/kernel/maidlab/api/consumer/service/ConsumerService.java
+++ b/api/src/main/java/kernel/maidlab/api/consumer/service/ConsumerService.java
@@ -114,8 +114,9 @@ public class ConsumerService {
         Manager manager = managerRepository.findByUuid(managerUuid)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매니저입니다."));
 
-        return managerPreferenceRepository.deleteByConsumerIdAndManagerIdAndPreferenceIsTrue(
-                consumer.getId(), manager.getId());
+        return managerPreferenceRepository.deleteByConsumerIdAndManagerId(
+                consumer.getId(),
+                manager.getId());
     }
 
     // 관리자용 전체조회로직


### PR DESCRIPTION
## #️⃣연관된 이슈

> #154 

## 📝작업 내용

> 
기존  찜한 매니저만 삭제가 가능했고 
블랙리스트 매니저는 삭제가 불가능 했다

둘다 삭제 가능 하도록  수정

### 스크린샷 (선택)




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
