### PR TITLE
refactor: Base 엔티티를 상속한 TimeBase 엔티티를 만듦. (생성 시간, 수정 시간) 게시판 상세 API호출시 생성 시간 가져오도록 수정

### DIFF
--- a/admin/src/main/java/kernel/maidlab/admin/auth/entity/Admin.java
+++ b/admin/src/main/java/kernel/maidlab/admin/auth/entity/Admin.java
@@ -2,6 +2,7 @@ package kernel.maidlab.admin.auth.entity;
 
 import java.time.LocalDateTime;
 
+import kernel.maidlab.common.entity.base.TimeBase;
 import org.hibernate.annotations.CreationTimestamp;
 
 import jakarta.persistence.Column;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "admin")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Admin extends Base {
+public class Admin extends TimeBase {
 
 	@Column(name = "admin_key", unique = true)
 	private String adminKey;

--- a/app/src/main/java/kernel/maidlab/MaidlabBeApplication.java
+++ b/app/src/main/java/kernel/maidlab/MaidlabBeApplication.java
@@ -3,7 +3,9 @@ package kernel.maidlab;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 @EnableFeignClients
 public class MaidlabBeApplication {

--- a/common/src/main/java/kernel/maidlab/common/dto/board/response/BoardDetailResponseDto.java
+++ b/common/src/main/java/kernel/maidlab/common/dto/board/response/BoardDetailResponseDto.java
@@ -20,7 +20,7 @@ public class BoardDetailResponseDto {
     private String content;
     private boolean isAnswered;
     private BoardType boardType;
-    private LocalDateTime createAt;
+    private LocalDateTime updatedAt;
     private List<ImageDto> images;
     private AnswerResponseDto answer;
 
@@ -32,7 +32,7 @@ public class BoardDetailResponseDto {
                 board.getContent(),
                 board.getIsAnswered(),
                 board.getBoardType(),
-                board.getCreatedAt(),
+                board.getUpdatedAt(),
                 images.stream()
                         .map(ImageDto::from)
                         .toList(),

--- a/common/src/main/java/kernel/maidlab/common/dto/board/response/BoardDetailResponseDto.java
+++ b/common/src/main/java/kernel/maidlab/common/dto/board/response/BoardDetailResponseDto.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -19,7 +20,7 @@ public class BoardDetailResponseDto {
     private String content;
     private boolean isAnswered;
     private BoardType boardType;
-//    private LocalDateTime createAt
+    private LocalDateTime createAt;
     private List<ImageDto> images;
     private AnswerResponseDto answer;
 
@@ -31,6 +32,7 @@ public class BoardDetailResponseDto {
                 board.getContent(),
                 board.getIsAnswered(),
                 board.getBoardType(),
+                board.getCreatedAt(),
                 images.stream()
                         .map(ImageDto::from)
                         .toList(),

--- a/common/src/main/java/kernel/maidlab/common/entity/base/TimeBase.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/base/TimeBase.java
@@ -1,0 +1,29 @@
+package kernel.maidlab.common.entity.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TimeBase extends Base{
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+}

--- a/common/src/main/java/kernel/maidlab/common/entity/board/Answer.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/board/Answer.java
@@ -6,13 +6,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import kernel.maidlab.common.dto.board.request.AnswerRequestDto;
 import kernel.maidlab.common.entity.base.Base;
+import kernel.maidlab.common.entity.base.TimeBase;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor
-public class Answer extends Base {
+public class Answer extends TimeBase {
 
     @OneToOne
     @JoinColumn(name = "board_id")

--- a/common/src/main/java/kernel/maidlab/common/entity/board/Board.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/board/Board.java
@@ -1,6 +1,7 @@
 package kernel.maidlab.common.entity.board;
 
 import jakarta.persistence.*;
+import kernel.maidlab.common.entity.base.TimeBase;
 import kernel.maidlab.common.entity.consumer.Consumer;
 import kernel.maidlab.common.entity.manager.Manager;
 import kernel.maidlab.common.entity.base.UserBase;
@@ -17,7 +18,7 @@ import java.util.List;
 @Getter
 @Entity
 @NoArgsConstructor
-public class Board extends Base {
+public class Board extends TimeBase {
 
     @ManyToOne
     @JoinColumn(name = "consumer_id")

--- a/common/src/main/java/kernel/maidlab/common/entity/consumer/Consumer.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/consumer/Consumer.java
@@ -2,6 +2,7 @@ package kernel.maidlab.common.entity.consumer;
 
 import jakarta.persistence.*;
 import kernel.maidlab.common.entity.base.Base;
+import kernel.maidlab.common.entity.base.TimeBase;
 import kernel.maidlab.common.entity.base.UserBase;
 import kernel.maidlab.common.enums.Gender;
 import kernel.maidlab.common.enums.SocialType;
@@ -23,7 +24,7 @@ import java.util.UUID;
 	@Index(name = "idx_consumer_phone_number", columnList = "phone_number", unique = true)})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Consumer extends Base implements UserBase {
+public class Consumer extends TimeBase implements UserBase {
 
 	@Column(name = "uuid", nullable = false, unique = true)
 	private String uuid;
@@ -62,14 +63,6 @@ public class Consumer extends Base implements UserBase {
 
 	@Column(name = "refresh_token", columnDefinition = "TEXT")
 	private String refreshToken;
-
-	@CreationTimestamp
-	@Column(name = "created_at", nullable = false)
-	private LocalDateTime createdAt;
-
-	@UpdateTimestamp
-	@Column(name = "updated_at")
-	private LocalDateTime updatedAt;
 
 	@Column(name = "is_deleted", nullable = false)
 	private Boolean isDeleted;

--- a/common/src/main/java/kernel/maidlab/common/entity/manager/Manager.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/manager/Manager.java
@@ -2,6 +2,7 @@ package kernel.maidlab.common.entity.manager;
 
 import jakarta.persistence.*;
 import kernel.maidlab.common.entity.base.Base;
+import kernel.maidlab.common.entity.base.TimeBase;
 import kernel.maidlab.common.entity.base.UserBase;
 import kernel.maidlab.common.enums.Gender;
 import kernel.maidlab.common.enums.Region;
@@ -26,7 +27,7 @@ import java.util.UUID;
 	@Index(name = "idx_manager_phone_number", columnList = "phone_number", unique = true)})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Manager extends Base implements UserBase {
+public class Manager extends TimeBase implements UserBase {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/common/src/main/java/kernel/maidlab/common/entity/reservation/Reservation.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/reservation/Reservation.java
@@ -14,6 +14,7 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import kernel.maidlab.common.dto.reservation.request.ReservationRequestDto;
 import kernel.maidlab.common.entity.base.Base;
+import kernel.maidlab.common.entity.base.TimeBase;
 import kernel.maidlab.common.enums.Status;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -23,7 +24,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "reservation")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Reservation extends Base {
+public class Reservation extends TimeBase {
 	@Column(name = "manager_id")
 	private Long managerId;
 

--- a/common/src/main/java/kernel/maidlab/common/entity/reservation/Review.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/reservation/Review.java
@@ -11,6 +11,7 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import kernel.maidlab.common.dto.reservation.request.ReviewRegisterRequestDto;
 import kernel.maidlab.common.entity.base.Base;
+import kernel.maidlab.common.entity.base.TimeBase;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "review")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Review extends Base {
+public class Review extends TimeBase {
 	@Column(name = "reservation_id", nullable = false)
 	private Long reservationId;
 	@Column(name = "manager_id", nullable = false)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #165 

## 📝작업 내용

> 
- 예약
- 게시판
- 수요자
- 매니저
- 어드민
- 답변
- 리뷰

일단 이렇게 TimeBase를 상속 받도록 만들었습니다. 
시간이 필요하지 엔티티는 TimeBase  상속을 지우지면 됩니다.

### 스크린샷 (선택)




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
