### PR TITLE
hotfix : 예약 내역 페이지 N+1 문제 해결 (JPA -> QueryDSL) & matching RsponseDto로 변경

### DIFF
--- a/api/src/main/java/kernel/maidlab/api/config/FilterConfig.java
+++ b/api/src/main/java/kernel/maidlab/api/config/FilterConfig.java
@@ -18,7 +18,7 @@ public class FilterConfig {
 		FilterRegistrationBean<Filter> registration = new FilterRegistrationBean<>();
 		registration.setFilter(jwtFilter);
 		registration.addUrlPatterns("/api/auth/*", "/api/consumers/*", "/api/manager/*",
-			"/api/board/*"); // 인증이 필요한 경로만 필터링
+			"/api/board/*", "/api/reservations/*"); // 인증이 필요한 경로만 필터링
 		registration.setName("jwtFilter");
 		registration.setOrder(1);
 

--- a/api/src/main/java/kernel/maidlab/api/matching/controller/MatchingApi.java
+++ b/api/src/main/java/kernel/maidlab/api/matching/controller/MatchingApi.java
@@ -32,7 +32,7 @@ public interface MatchingApi {
 		@ApiResponse(responseCode = "401", description = "비로그인 접속"),
 		@ApiResponse(responseCode = "403", description = "권한 없음"),
 		@ApiResponse(responseCode = "500", description = "데이터베이스 오류")})
-	ResponseEntity<List<AvailableManagerResponseDto>> matchManagers(@RequestBody MatchingRequestDto dto);
+	ResponseEntity<ResponseDto<List<AvailableManagerResponseDto>>> matchManagers(@RequestBody MatchingRequestDto dto);
 
 	@Operation(summary = "매칭시작", description = "매칭 테이블에 reservationid, status, managerid 값들로 row 생성")
 	@ApiResponses({@ApiResponse(responseCode = "200", description = "테이블 생성 성공"),

--- a/api/src/main/java/kernel/maidlab/api/matching/controller/MatchingController.java
+++ b/api/src/main/java/kernel/maidlab/api/matching/controller/MatchingController.java
@@ -44,7 +44,7 @@ public class MatchingController implements MatchingApi {
 
 	@PostMapping("/matchmanager")
 	@Override
-	public ResponseEntity<List<AvailableManagerResponseDto>> matchManagers(@RequestBody MatchingRequestDto dto) {
+	public ResponseEntity<ResponseDto<List<AvailableManagerResponseDto>>> matchManagers(@RequestBody MatchingRequestDto dto) {
 		List<AvailableManagerResponseDto> AvailableManagers = matchingService.findAvailableManagers(dto);
 
 		// 후보군 작성을 위한 redis 설정으로 일단 일시중지
@@ -56,9 +56,11 @@ public class MatchingController implements MatchingApi {
 		}
 
 		if (dto.getManagerChoose())
-			return ResponseEntity.ok(AvailableManagers);
+			return ResponseDto.success(ResponseType.SUCCESS, AvailableManagers);
+			// return ResponseEntity.ok(AvailableManagers);
 		else
-			return ResponseEntity.ok(Collections.singletonList(AvailableManagers.getFirst()));
+			// return ResponseEntity.ok(Collections.singletonList(AvailableManagers.getFirst()));
+			return ResponseDto.success(ResponseType.SUCCESS, Collections.singletonList(AvailableManagers.getFirst()));
 	}
 
 	@PostMapping("/matchstart")

--- a/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepository.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepository.java
@@ -1,7 +1,6 @@
 package kernel.maidlab.api.reservation.repository;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,13 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import kernel.maidlab.common.entity.reservation.Reservation;
 
-public interface ReservationRepository extends JpaRepository<Reservation, Long> {
-
-	List<Reservation> findByConsumerId(Long consumerId);
-
-	List<Reservation> findByManagerId(Long managerId);
-
+public interface ReservationRepository extends JpaRepository<Reservation, Long>, ReservationRepositoryCustom {
 	Page<Reservation> findAllByReservationDateBetween(LocalDateTime start, LocalDateTime end, Pageable pageable);
-	// List<Reservation> findByReservationDateBetween(LocalDateTime start, LocalDateTime end);
-	// List<Reservation> findByStatus(ReservationStatus status);
 }

--- a/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustom.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustom.java
@@ -1,12 +1,18 @@
 package kernel.maidlab.api.reservation.repository;
 
 import java.util.List;
+import java.util.Optional;
 
+import kernel.maidlab.common.dto.reservation.response.ReservationDetailResponseDto;
 import kernel.maidlab.common.dto.reservation.response.ReservationResponseDto;
+import kernel.maidlab.common.enums.UserType;
 
 public interface ReservationRepositoryCustom {
 	List<ReservationResponseDto> findAllWithReviewByConsumerId(Long consumerId);
 
 	List<ReservationResponseDto> findAllWithReviewByManagerId(Long managerId);
+
+	ReservationDetailResponseDto findDetailReservationByIdAndUser(Long reservationId, Long userId, UserType userType);
+
 
 }

--- a/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustom.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustom.java
@@ -1,0 +1,12 @@
+package kernel.maidlab.api.reservation.repository;
+
+import java.util.List;
+
+import kernel.maidlab.common.dto.reservation.response.ReservationResponseDto;
+
+public interface ReservationRepositoryCustom {
+	List<ReservationResponseDto> findAllWithReviewByConsumerId(Long consumerId);
+
+	List<ReservationResponseDto> findAllWithReviewByManagerId(Long managerId);
+
+}

--- a/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustomImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustomImpl.java
@@ -31,6 +31,9 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 	QReservation reservation = QReservation.reservation;
 	QServiceDetailType serviceDetailType = QServiceDetailType.serviceDetailType1;
 	QReview review = QReview.review;
+	QManager manager = QManager.manager;
+	QManagerRegion managerRegion = QManagerRegion.managerRegion;
+	QRegion region = QRegion.region;
 
 	@Override
 	public List<ReservationResponseDto> findAllWithReviewByConsumerId(Long consumerId) {
@@ -61,24 +64,24 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 
 	@Override
 	public ReservationDetailResponseDto findDetailReservationByIdAndUser(Long reservationId, Long userId, UserType userType) {
-		QReservation reservation = QReservation.reservation;
-		QManager manager = QManager.manager;
-		QManagerRegion managerRegion = QManagerRegion.managerRegion;
-		QRegion region = QRegion.region;
-		QServiceDetailType sdt = QServiceDetailType.serviceDetailType1;
+
 
 		// 사용자 일치 조건 (권한 체크)
 		BooleanExpression userCondition = (userType == UserType.MANAGER)
 			? reservation.managerId.eq(userId)
 			: reservation.consumerId.eq(userId);
 
-		// 한 번에 가져오기
+		// 방어코드: userCondition null일 수 있으므로
+		if (userCondition == null) {
+			throw new ReservationException(ResponseType.THIS_USER_DOES_NOT_EXIST);
+		}
+
 		List<Tuple> tuples = queryFactory
 			.select(
 				reservation.id,
 				reservation.status,
-				sdt.serviceType.stringValue(),
-				sdt.serviceDetailType,
+				serviceDetailType.serviceType.stringValue(),
+				serviceDetailType.serviceDetailType,
 				reservation.address,
 				reservation.addressDetail,
 				manager.uuid,
@@ -99,7 +102,7 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 				region.regionName
 			)
 			.from(reservation)
-			.join(reservation.serviceDetailType, sdt)
+			.join(reservation.serviceDetailType, serviceDetailType)
 			.join(manager).on(manager.id.eq(reservation.managerId))
 			.leftJoin(managerRegion).on(managerRegion.manager.id.eq(manager.id))
 			.leftJoin(region).on(region.id.eq(managerRegion.regionId.id))
@@ -107,7 +110,7 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 			.fetch();
 
 		if (tuples.isEmpty()) {
-			throw new ReservationException(ResponseType.DATABASE_ERROR);
+			throw new ReservationException(ResponseType.THIS_USER_DOES_NOT_EXIST);
 		}
 
 		Tuple first = tuples.getFirst();
@@ -117,29 +120,28 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 			.collect(Collectors.toList());
 
 		return ReservationDetailResponseDto.builder()
-				.status(first.get(reservation.status))
-				.serviceType(first.get(sdt.serviceType.stringValue()))
-				.serviceDetailType(first.get(sdt.serviceDetailType))
-				.address(first.get(reservation.address))
-				.addressDetail(first.get(reservation.addressDetail))
-				.managerUuId(first.get(manager.uuid))
-				.managerName(first.get(manager.name))
-				.managerProfileImageUrl(first.get(manager.profileImage))
-				.managerAverageRate(first.get(manager.averageRate))
-				.managerRegion(regionNames)
-				.managerPhoneNumber(first.get(manager.phoneNumber))
-				.housingType(first.get(reservation.housingType))
-				.roomSize(first.get(reservation.roomSize))
-				.housingInformation(first.get(reservation.housingInformation))
-				.reservationDate(first.get(reservation.reservationDate))
-				.startTime(first.get(reservation.startTime))
-				.endTime(first.get(reservation.endTime))
-				.serviceAdd(first.get(reservation.serviceAdd))
-				.pet(first.get(reservation.pet))
-				.specialRequest(first.get(reservation.specialRequest))
-				.totalPrice(first.get(reservation.totalPrice))
-				.build();
+			.status(first.get(reservation.status))
+			.serviceType(first.get(serviceDetailType.serviceType.stringValue()))
+			.serviceDetailType(first.get(serviceDetailType.serviceDetailType))
+			.address(first.get(reservation.address))
+			.addressDetail(first.get(reservation.addressDetail))
+			.managerUuId(first.get(manager.uuid))
+			.managerName(first.get(manager.name))
+			.managerProfileImageUrl(first.get(manager.profileImage))
+			.managerAverageRate(first.get(manager.averageRate))
+			.managerRegion(regionNames)
+			.managerPhoneNumber(first.get(manager.phoneNumber))
+			.housingType(first.get(reservation.housingType))
+			.roomSize(first.get(reservation.roomSize))
+			.housingInformation(first.get(reservation.housingInformation))
+			.reservationDate(first.get(reservation.reservationDate))
+			.startTime(first.get(reservation.startTime))
+			.endTime(first.get(reservation.endTime))
+			.serviceAdd(first.get(reservation.serviceAdd))
+			.pet(first.get(reservation.pet))
+			.specialRequest(first.get(reservation.specialRequest))
+			.totalPrice(first.get(reservation.totalPrice))
+			.build();
 	}
-
 
 }

--- a/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustomImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustomImpl.java
@@ -1,16 +1,26 @@
 package kernel.maidlab.api.reservation.repository;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import kernel.maidlab.common.dto.reservation.response.ReservationDetailResponseDto;
 import kernel.maidlab.common.dto.reservation.response.ReservationResponseDto;
+import kernel.maidlab.common.entity.manager.QManager;
+import kernel.maidlab.common.entity.manager.QManagerRegion;
+import kernel.maidlab.common.entity.manager.QRegion;
 import kernel.maidlab.common.entity.reservation.QReservation;
 import kernel.maidlab.common.entity.reservation.QReview;
 import kernel.maidlab.common.entity.reservation.QServiceDetailType;
+import kernel.maidlab.common.enums.ResponseType;
+import kernel.maidlab.common.enums.UserType;
+import kernel.maidlab.common.exception.custom.ReservationException;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -48,4 +58,88 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 			.where(condition)
 			.fetch();
 	}
+
+	@Override
+	public ReservationDetailResponseDto findDetailReservationByIdAndUser(Long reservationId, Long userId, UserType userType) {
+		QReservation reservation = QReservation.reservation;
+		QManager manager = QManager.manager;
+		QManagerRegion managerRegion = QManagerRegion.managerRegion;
+		QRegion region = QRegion.region;
+		QServiceDetailType sdt = QServiceDetailType.serviceDetailType1;
+
+		// 사용자 일치 조건 (권한 체크)
+		BooleanExpression userCondition = (userType == UserType.MANAGER)
+			? reservation.managerId.eq(userId)
+			: reservation.consumerId.eq(userId);
+
+		// 한 번에 가져오기
+		List<Tuple> tuples = queryFactory
+			.select(
+				reservation.id,
+				reservation.status,
+				sdt.serviceType.stringValue(),
+				sdt.serviceDetailType,
+				reservation.address,
+				reservation.addressDetail,
+				manager.uuid,
+				manager.name,
+				manager.profileImage,
+				manager.averageRate,
+				manager.phoneNumber,
+				reservation.housingType,
+				reservation.roomSize,
+				reservation.housingInformation,
+				reservation.reservationDate,
+				reservation.startTime,
+				reservation.endTime,
+				reservation.serviceAdd,
+				reservation.pet,
+				reservation.specialRequest,
+				reservation.totalPrice,
+				region.regionName
+			)
+			.from(reservation)
+			.join(reservation.serviceDetailType, sdt)
+			.join(manager).on(manager.id.eq(reservation.managerId))
+			.leftJoin(managerRegion).on(managerRegion.manager.id.eq(manager.id))
+			.leftJoin(region).on(region.id.eq(managerRegion.regionId.id))
+			.where(reservation.id.eq(reservationId).and(userCondition))
+			.fetch();
+
+		if (tuples.isEmpty()) {
+			throw new ReservationException(ResponseType.DATABASE_ERROR);
+		}
+
+		Tuple first = tuples.getFirst();
+		List<String> regionNames = tuples.stream()
+			.map(t -> t.get(region.regionName))
+			.distinct()
+			.collect(Collectors.toList());
+
+		return ReservationDetailResponseDto.builder()
+				.status(first.get(reservation.status))
+				.serviceType(first.get(sdt.serviceType.stringValue()))
+				.serviceDetailType(first.get(sdt.serviceDetailType))
+				.address(first.get(reservation.address))
+				.addressDetail(first.get(reservation.addressDetail))
+				.managerUuId(first.get(manager.uuid))
+				.managerName(first.get(manager.name))
+				.managerProfileImageUrl(first.get(manager.profileImage))
+				.managerAverageRate(first.get(manager.averageRate))
+				.managerRegion(regionNames)
+				.managerPhoneNumber(first.get(manager.phoneNumber))
+				.housingType(first.get(reservation.housingType))
+				.roomSize(first.get(reservation.roomSize))
+				.housingInformation(first.get(reservation.housingInformation))
+				.reservationDate(first.get(reservation.reservationDate))
+				.startTime(first.get(reservation.startTime))
+				.endTime(first.get(reservation.endTime))
+				.serviceAdd(first.get(reservation.serviceAdd))
+				.pet(first.get(reservation.pet))
+				.specialRequest(first.get(reservation.specialRequest))
+				.totalPrice(first.get(reservation.totalPrice))
+				.build();
+	}
+
+
 }

--- a/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustomImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustomImpl.java
@@ -1,0 +1,51 @@
+package kernel.maidlab.api.reservation.repository;
+
+import java.util.List;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import kernel.maidlab.common.dto.reservation.response.ReservationResponseDto;
+import kernel.maidlab.common.entity.reservation.QReservation;
+import kernel.maidlab.common.entity.reservation.QReview;
+import kernel.maidlab.common.entity.reservation.QServiceDetailType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ReservationRepositoryCustomImpl implements ReservationRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	QReservation reservation = QReservation.reservation;
+	QServiceDetailType serviceDetailType = QServiceDetailType.serviceDetailType1;
+	QReview review = QReview.review;
+
+	@Override
+	public List<ReservationResponseDto> findAllWithReviewByConsumerId(Long consumerId) {
+		return findAllWithReviewByUserCondition(reservation.consumerId.eq(consumerId));
+	}
+
+	@Override
+	public List<ReservationResponseDto> findAllWithReviewByManagerId(Long managerId) {
+		return findAllWithReviewByUserCondition(reservation.managerId.eq(managerId));
+	}
+
+	private List<ReservationResponseDto> findAllWithReviewByUserCondition(BooleanExpression condition) {
+		return queryFactory.select(
+				Projections.constructor(ReservationResponseDto.class, reservation.id, reservation.status,
+					reservation.serviceDetailType.serviceType.stringValue(),
+					reservation.serviceDetailType.serviceDetailType,
+					reservation.reservationDate.stringValue(),
+					reservation.startTime.stringValue().substring(11, 16),
+					reservation.endTime.stringValue().substring(11, 16),
+					// 리뷰 존재 여부 확인 (EXISTS 서브쿼리)
+					JPAExpressions.selectOne().from(review).where(review.reservationId.eq(reservation.id)).exists(),
+					reservation.totalPrice))
+			.from(reservation)
+			.join(reservation.serviceDetailType, serviceDetailType)
+			.where(condition)
+			.fetch();
+	}
+}

--- a/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
@@ -130,17 +130,18 @@ public class ReservationServiceImpl implements ReservationService {
 
 	@Override
 	public ReservationDetailResponseDto getReservationDetail(Long reservationId, HttpServletRequest request) {
-		UserType userType = authUtil.getUserType(request);
 
-		if (userType == UserType.CONSUMER) {
-			Long consumerId = authUtil.getConsumer(request).getId();
-			return reservationRepository.findDetailReservationByIdAndUser(reservationId, consumerId, userType);
-		} else {
-			Long managerId = authUtil.getManager(request).getId();
-			return reservationRepository.findDetailReservationByIdAndUser(reservationId, managerId, userType);
-		}
+		UserBase user = (UserBase) request.getAttribute(JwtFilter.CURRENT_USER_KEY);
+		UserType userType = (UserType) request.getAttribute(JwtFilter.CURRENT_USER_TYPE_KEY);
+		Long userId = switch (userType) {
+			case CONSUMER -> ((Consumer) user).getId();
+			case MANAGER -> ((Manager) user).getId();
+			default -> throw new ReservationException(ResponseType.THIS_USER_DOES_NOT_EXIST);
+		};
 
+		return reservationRepository.findDetailReservationByIdAndUser(reservationId, userId, userType);
 	}
+
 
 
 

--- a/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
@@ -20,6 +20,8 @@ import org.springframework.stereotype.Service;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.transaction.Transactional;
+import kernel.maidlab.api.auth.jwt.JwtFilter;
+import kernel.maidlab.common.entity.base.UserBase;
 import kernel.maidlab.common.entity.consumer.Consumer;
 import kernel.maidlab.common.entity.manager.Manager;
 import kernel.maidlab.common.entity.consumer.ManagerPreference;
@@ -128,44 +130,15 @@ public class ReservationServiceImpl implements ReservationService {
 
 	@Override
 	public ReservationDetailResponseDto getReservationDetail(Long reservationId, HttpServletRequest request) {
-		Reservation reservation = reservationRepository.findById(reservationId)
-			.orElseThrow(() -> new ReservationException(ResponseType.DATABASE_ERROR));
-		Manager manager = managerRepository.findById(reservation.getManagerId())
-			.orElseThrow(() -> new ReservationException(ResponseType.DATABASE_ERROR));
+		UserType userType = (UserType) request.getAttribute(JwtFilter.CURRENT_USER_TYPE_KEY);
+		UserBase user = (UserBase) request.getAttribute(JwtFilter.CURRENT_USER_KEY);
+		Long userId = getUserId(request, userType);
 
-		String mangerUuid = manager.getUuid();
-		Long managerId = manager.getId();
-		List<ManagerRegion> managerRegions = managerRegionRepository.findByManagerId(manager.getId());
-		List<String> regionNames = managerRegions.stream()
-			.map(mr -> regionRepository.findById(mr.getRegionId().getId())
-				.orElseThrow(() -> new ReservationException(ResponseType.DATABASE_ERROR))
-				.getRegionName())
-			.collect(toList());
-
-		return ReservationDetailResponseDto.builder()
-			.status(reservation.getStatus())
-			.serviceType(reservation.getServiceDetailType().getServiceType().toString())
-			.serviceDetailType(reservation.getServiceDetailType().getServiceDetailType())
-			.address(reservation.getAddress())
-			.addressDetail(reservation.getAddressDetail())
-			.managerUuId(mangerUuid)
-			.managerName(manager.getName())
-			.managerProfileImageUrl(manager.getProfileImage())
-			.managerAverageRate(manager.getAverageRate())
-			.managerRegion(regionNames)
-			.managerPhoneNumber(manager.getPhoneNumber())
-			.housingType(reservation.getHousingType())
-			.roomSize(reservation.getRoomSize())
-			.housingInformation(reservation.getHousingInformation())
-			.reservationDate(reservation.getReservationDate())
-			.startTime(reservation.getStartTime())
-			.endTime(reservation.getEndTime())
-			.serviceAdd(reservation.getServiceAdd())
-			.pet(reservation.getPet())
-			.specialRequest(reservation.getSpecialRequest())
-			.totalPrice(reservation.getTotalPrice())
-			.build();
+		return reservationRepository.findDetailReservationByIdAndUser(reservationId, userId, userType);
 	}
+
+
+
 
 	@Transactional
 	@Override
@@ -444,6 +417,18 @@ public class ReservationServiceImpl implements ReservationService {
 	public void settlementReject(Long settlementId) {
 		Optional<Settlement> settlement = settlementRepository.findById(settlementId);
 		settlement.get().reject();
+	}
+
+
+	public Long getUserId(HttpServletRequest request, UserType userType) {
+		UserBase user = (UserBase) request.getAttribute(JwtFilter.CURRENT_USER_KEY);
+		if (userType == UserType.CONSUMER) {
+			return ((Consumer) user).getId();
+		} else if (userType == UserType.MANAGER) {
+			return ((Manager) user).getId();
+		} else {
+			throw new ReservationException(ResponseType.THIS_USER_DOES_NOT_EXIST);
+		}
 	}
 }
 

--- a/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
@@ -130,11 +130,16 @@ public class ReservationServiceImpl implements ReservationService {
 
 	@Override
 	public ReservationDetailResponseDto getReservationDetail(Long reservationId, HttpServletRequest request) {
-		UserType userType = (UserType) request.getAttribute(JwtFilter.CURRENT_USER_TYPE_KEY);
-		UserBase user = (UserBase) request.getAttribute(JwtFilter.CURRENT_USER_KEY);
-		Long userId = getUserId(request, userType);
+		UserType userType = authUtil.getUserType(request);
 
-		return reservationRepository.findDetailReservationByIdAndUser(reservationId, userId, userType);
+		if (userType == UserType.CONSUMER) {
+			Long consumerId = authUtil.getConsumer(request).getId();
+			return reservationRepository.findDetailReservationByIdAndUser(reservationId, consumerId, userType);
+		} else {
+			Long managerId = authUtil.getManager(request).getId();
+			return reservationRepository.findDetailReservationByIdAndUser(reservationId, managerId, userType);
+		}
+
 	}
 
 

--- a/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
@@ -115,29 +115,15 @@ public class ReservationServiceImpl implements ReservationService {
 	@Override
 	public List<ReservationResponseDto> allReservations(HttpServletRequest request) {
 		UserType userType = authUtil.getUserType(request);
-		List<Reservation> reservations;
 
 		if (userType == UserType.CONSUMER) {
 			Long consumerId = authUtil.getConsumer(request).getId();
-			reservations = reservationRepository.findByConsumerId(consumerId);
+			return reservationRepository.findAllWithReviewByConsumerId(consumerId);
 		} else {
 			Long managerId = authUtil.getManager(request).getId();
-			reservations = reservationRepository.findByManagerId(managerId);
-		}
+			return reservationRepository.findAllWithReviewByManagerId(managerId);
 
-		return reservations.stream()
-			.map(reservation -> ReservationResponseDto.builder()
-				.reservationId(reservation.getId())
-				.isExistReview(reviewRepository.existsReviewsByReservationId(reservation.getId()))
-				.status(reservation.getStatus())
-				.serviceType(reservation.getServiceDetailType().getServiceType().toString())
-				.detailServiceType(reservation.getServiceDetailType().getServiceDetailType())
-				.reservationDate(reservation.getReservationDate().toLocalDate().toString())
-				.startTime(reservation.getStartTime().toLocalTime().toString().substring(0, 5))
-				.endTime(reservation.getEndTime().toLocalTime().toString().substring(0, 5))
-				.totalPrice(reservation.getTotalPrice())
-				.build())
-			.toList();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
## #️⃣연관된 이슈

#162 

## 📝작업 내용

- 예약 내역 페이지 N+1 문제 해결 (JPA -> QueryDSL)
- 예약 상세 내역 페이지 N+1 문제 해결 (JPA -> QueryDSL) 
- matchManagers 통일 된 반환값으로 수정 ResponseEntity.ok -> ResponseDto.success(ResponseType.SUCCESS, AvailableManagers);
