### PR TITLE
Feature/be/#179

### DIFF
--- a/admin/src/main/java/kernel/maidlab/admin/board/controller/AdminBoardControllerImpl.java
+++ b/admin/src/main/java/kernel/maidlab/admin/board/controller/AdminBoardControllerImpl.java
@@ -29,7 +29,6 @@ import lombok.RequiredArgsConstructor;
 public class AdminBoardControllerImpl implements AdminBoardApi {
 
 	private final AdminBoardServiceImpl adminBoardService;
-	private final BoardService boardService;
 
 	@GetMapping("/refund")
 	@Override

--- a/api/src/main/java/kernel/maidlab/api/manager/repository/ManagerRepositoryCustom.java
+++ b/api/src/main/java/kernel/maidlab/api/manager/repository/ManagerRepositoryCustom.java
@@ -3,8 +3,12 @@ package kernel.maidlab.api.manager.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import jakarta.servlet.http.HttpServletRequest;
 import kernel.maidlab.common.dto.matching.response.AvailableManagerResponseDto;
+import kernel.maidlab.common.entity.consumer.Consumer;
 
 public interface ManagerRepositoryCustom {
 	List<AvailableManagerResponseDto> findAvailableManagers(String site, LocalDateTime start, LocalDateTime end);
+
+	List<AvailableManagerResponseDto> previousManagers(Consumer consumer);
 }

--- a/api/src/main/java/kernel/maidlab/api/manager/repository/ManagerRepositoryCustomImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/manager/repository/ManagerRepositoryCustomImpl.java
@@ -12,6 +12,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import jakarta.servlet.http.HttpServletRequest;
 import kernel.maidlab.common.dto.matching.response.AvailableManagerResponseDto;
 
 import static kernel.maidlab.common.entity.manager.QManager.manager;
@@ -19,7 +20,9 @@ import static kernel.maidlab.common.entity.manager.QManagerRegion.managerRegion;
 import static kernel.maidlab.common.entity.manager.QManagerSchedule.managerSchedule;
 import static kernel.maidlab.common.entity.manager.QRegion.region;
 import static kernel.maidlab.common.entity.reservation.QReservation.reservation;
+import static kernel.maidlab.common.entity.consumer.QManagerPreference.managerPreference;
 
+import kernel.maidlab.common.entity.consumer.Consumer;
 import kernel.maidlab.common.enums.Status;
 import lombok.RequiredArgsConstructor;
 
@@ -56,6 +59,23 @@ public class ManagerRepositoryCustomImpl implements ManagerRepositoryCustom {
 							reservation.startTime.lt(end),     // 예약 시작 < 요청 종료
 							reservation.endTime.gt(start)      // 예약 종료 > 요청 시작
 						)))
+			.fetch();
+	}
+
+	@Override
+	public List<AvailableManagerResponseDto> previousManagers(Consumer consumer){
+		return QueryFactory.select(
+				Projections.constructor(AvailableManagerResponseDto.class, manager.uuid, manager.name, manager.averageRate,
+					manager.introduceText, manager.profileImage))
+			.from(manager)
+			.join(reservation)
+			.on(manager.id.eq(reservation.managerId))
+			.where(reservation.consumerId.eq(consumer.getId()), reservation.status.eq(Status.COMPLETED), manager.id.notIn(
+				JPAExpressions.select(managerPreference.manager.id)
+					.from(managerPreference)
+					.where(managerPreference.consumer.id.eq(consumer.getId()),
+						managerPreference.preference.isFalse())
+			))
 			.fetch();
 	}
 

--- a/api/src/main/java/kernel/maidlab/api/manager/service/ManagerService.java
+++ b/api/src/main/java/kernel/maidlab/api/manager/service/ManagerService.java
@@ -17,6 +17,7 @@ import jakarta.transaction.Transactional;
 import kernel.maidlab.common.dto.manager.ManagerListResponseDto;
 import kernel.maidlab.common.dto.manager.ManagerResponseDto;
 import kernel.maidlab.common.dto.matching.response.AvailableManagerResponseDto;
+import kernel.maidlab.common.entity.consumer.Consumer;
 import kernel.maidlab.common.enums.Status;
 
 public interface ManagerService {
@@ -32,4 +33,6 @@ public interface ManagerService {
 	ResponseEntity<ResponseDto<ReviewListResponseDto>> getMyReviews(HttpServletRequest req);
 
 	List<AvailableManagerResponseDto> findAvailableManagers(String gu, LocalDateTime StartTime, LocalDateTime EndTime);
+
+	List<AvailableManagerResponseDto> previousManagers(Consumer consumer);
 }

--- a/api/src/main/java/kernel/maidlab/api/manager/service/ManagerServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/manager/service/ManagerServiceImpl.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 // import jakarta.transaction.Transactional;
 import kernel.maidlab.common.dto.matching.response.AvailableManagerResponseDto;
+import kernel.maidlab.common.entity.consumer.Consumer;
 import kernel.maidlab.common.entity.manager.Manager;
 import kernel.maidlab.common.dto.auth.JwtDto;
 import kernel.maidlab.api.auth.jwt.JwtProvider;
@@ -287,6 +288,11 @@ public class ManagerServiceImpl implements ManagerService {
 	public List<AvailableManagerResponseDto> findAvailableManagers(String gu, LocalDateTime StartTime,
 		LocalDateTime EndTime) {
 		return managerRepository.findAvailableManagers(gu, StartTime, EndTime);
+	}
+
+	@Override
+	public List<AvailableManagerResponseDto> previousManagers(Consumer consumer){
+		return managerRepository.previousManagers(consumer);
 	}
 
 }

--- a/api/src/main/java/kernel/maidlab/api/matching/controller/MatchingApi.java
+++ b/api/src/main/java/kernel/maidlab/api/matching/controller/MatchingApi.java
@@ -3,6 +3,7 @@ package kernel.maidlab.api.matching.controller;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import kernel.maidlab.common.dto.consumer.response.LikedManagerResponseDto;
 import kernel.maidlab.common.dto.matching.response.AvailableManagerResponseDto;
 import kernel.maidlab.common.dto.matching.request.MatchingRequestDto;
 import kernel.maidlab.common.dto.matching.response.RequestMatchingListResponseDto;
@@ -33,6 +35,23 @@ public interface MatchingApi {
 		@ApiResponse(responseCode = "403", description = "권한 없음"),
 		@ApiResponse(responseCode = "500", description = "데이터베이스 오류")})
 	ResponseEntity<ResponseDto<List<AvailableManagerResponseDto>>> matchManagers(@RequestBody MatchingRequestDto dto);
+
+	@Operation(summary = "선호 매니저 조회", description = "선호하는 매니저만을 조회합니다.")
+	@ApiResponses({@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "400", description = "선호 매니저가 없습니다."),
+		@ApiResponse(responseCode = "401", description = "비로그인 접속"),
+		@ApiResponse(responseCode = "403", description = "권한 없음"),
+		@ApiResponse(responseCode = "500", description = "데이터베이스 오류")})
+	@GetMapping("/preferencemanager")
+	ResponseEntity<ResponseDto<List<LikedManagerResponseDto>>> preferenceManager(HttpServletRequest request);
+	@Operation(summary = "이전 매니저 조회", description = "이전에 서비스를 받았던 매니저를 조회합니다.")
+	@ApiResponses({@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "400", description = "선호 매니저가 없습니다."),
+		@ApiResponse(responseCode = "401", description = "비로그인 접속"),
+		@ApiResponse(responseCode = "403", description = "권한 없음"),
+		@ApiResponse(responseCode = "500", description = "데이터베이스 오류")})
+	@GetMapping("/previousmanager")
+	ResponseEntity<ResponseDto<List<AvailableManagerResponseDto>>> previousManager(HttpServletRequest request);
 
 	@Operation(summary = "매칭시작", description = "매칭 테이블에 reservationid, status, managerid 값들로 row 생성")
 	@ApiResponses({@ApiResponse(responseCode = "200", description = "테이블 생성 성공"),

--- a/api/src/main/java/kernel/maidlab/api/matching/controller/MatchingController.java
+++ b/api/src/main/java/kernel/maidlab/api/matching/controller/MatchingController.java
@@ -12,7 +12,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.servlet.http.HttpServletRequest;
+import kernel.maidlab.api.consumer.service.ConsumerService;
+import kernel.maidlab.common.dto.consumer.response.LikedManagerResponseDto;
 import kernel.maidlab.common.dto.matching.response.RequestMatchingListResponseDto;
+import kernel.maidlab.common.entity.consumer.Consumer;
 import kernel.maidlab.common.exception.BaseException;
 import kernel.maidlab.common.dto.matching.response.AvailableManagerResponseDto;
 import kernel.maidlab.common.dto.matching.request.MatchingRequestDto;
@@ -30,6 +33,7 @@ public class MatchingController implements MatchingApi {
 
 	// private final AuthUtil authUtil;
 	private final MatchingService matchingService;
+	private final ConsumerService consumerService;
 	// private final MatchingRepository matchingRepository;
 	// private final RedisTemplate<String, Object> redisTemplate;
 	// private final RedisService redisService;
@@ -63,6 +67,21 @@ public class MatchingController implements MatchingApi {
 			return ResponseDto.success(ResponseType.SUCCESS, Collections.singletonList(AvailableManagers.getFirst()));
 	}
 
+	@GetMapping("/preferencemanager")
+	@Override
+	public ResponseEntity<ResponseDto<List<LikedManagerResponseDto>>> preferenceManager(HttpServletRequest request) {
+		List<LikedManagerResponseDto> response = matchingService.preferenceManager(request);
+		return ResponseDto.success(ResponseType.SUCCESS, response);
+	}
+
+	@GetMapping("/previousmanager")
+	@Override
+	public ResponseEntity<ResponseDto<List<AvailableManagerResponseDto>>> previousManager(HttpServletRequest request) {
+		Consumer consumer = consumerService.getConsumer(request);
+		List<AvailableManagerResponseDto> response = matchingService.previousManager(consumer);
+		return ResponseDto.success(ResponseType.SUCCESS, response);
+	}
+
 	@PostMapping("/matchstart")
 	@Override
 	public ResponseEntity<ResponseDto<String>> matchStart(@RequestParam Long reservation_id,
@@ -75,5 +94,6 @@ public class MatchingController implements MatchingApi {
 		matchingService.createMatching(matchingResponseDto);
 		return ResponseDto.success(ResponseType.SUCCESS, matchingResponseDto.toString());
 	}
+
 
 }

--- a/api/src/main/java/kernel/maidlab/api/matching/service/MatchingService.java
+++ b/api/src/main/java/kernel/maidlab/api/matching/service/MatchingService.java
@@ -3,10 +3,12 @@ package kernel.maidlab.api.matching.service;
 import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
+import kernel.maidlab.common.dto.consumer.response.LikedManagerResponseDto;
 import kernel.maidlab.common.dto.matching.response.AvailableManagerResponseDto;
 import kernel.maidlab.common.dto.matching.response.MatchingResponseDto;
 import kernel.maidlab.common.dto.matching.request.MatchingRequestDto;
 import kernel.maidlab.common.dto.matching.response.RequestMatchingListResponseDto;
+import kernel.maidlab.common.entity.consumer.Consumer;
 import kernel.maidlab.common.enums.Status;
 
 public interface MatchingService {
@@ -19,4 +21,7 @@ public interface MatchingService {
 
 	List<RequestMatchingListResponseDto> myMatching(HttpServletRequest request, int page, int size);
 
+	List<LikedManagerResponseDto> preferenceManager(HttpServletRequest request);
+
+	List<AvailableManagerResponseDto> previousManager(Consumer consumer);
 }

--- a/api/src/main/java/kernel/maidlab/api/matching/service/MatchingServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/matching/service/MatchingServiceImpl.java
@@ -12,10 +12,12 @@ import org.springframework.stereotype.Service;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.transaction.Transactional;
 import kernel.maidlab.api.auth.jwt.JwtFilter;
+import kernel.maidlab.api.consumer.service.ConsumerService;
 import kernel.maidlab.api.manager.service.ManagerService;
 import kernel.maidlab.api.reservation.repository.ReservationRepository;
-import kernel.maidlab.api.reservation.service.ReservationService;
+import kernel.maidlab.common.dto.consumer.response.LikedManagerResponseDto;
 import kernel.maidlab.common.entity.base.UserBase;
+import kernel.maidlab.common.entity.consumer.Consumer;
 import kernel.maidlab.common.entity.manager.Manager;
 import kernel.maidlab.common.dto.matching.response.RequestMatchingListResponseDto;
 import kernel.maidlab.common.entity.reservation.Reservation;
@@ -27,19 +29,15 @@ import kernel.maidlab.common.entity.matching.Matching;
 import kernel.maidlab.api.matching.repository.MatchingRepository;
 import kernel.maidlab.common.enums.ResponseType;
 import kernel.maidlab.common.enums.Status;
+import lombok.RequiredArgsConstructor;
 
 @Service
+@RequiredArgsConstructor
 public class MatchingServiceImpl implements MatchingService {
 	private final MatchingRepository matchingRepository;
 	private final ManagerService managerService;
 	private final ReservationRepository reservationRepository;
-
-	public MatchingServiceImpl(MatchingRepository matchingRepository, ManagerService managerService,
-		ReservationRepository reservationRepository) {
-		this.matchingRepository = matchingRepository;
-		this.managerService = managerService;
-		this.reservationRepository = reservationRepository;
-	}
+	private final ConsumerService consumerService;
 
 	@Override
 	public List<AvailableManagerResponseDto> findAvailableManagers(MatchingRequestDto dto) {
@@ -85,6 +83,16 @@ public class MatchingServiceImpl implements MatchingService {
 				return new RequestMatchingListResponseDto(reservation);
 			})
 			.toList();
+	}
+
+	@Override
+	public List<LikedManagerResponseDto> preferenceManager(HttpServletRequest request) {
+		return consumerService.getLikedManagerList(request);
+	}
+
+	@Override
+	public List<AvailableManagerResponseDto> previousManager(Consumer consumer) {
+		return managerService.previousManagers(consumer);
 	}
 
 	private String extractGuFromAddress(String address) {

--- a/api/src/main/java/kernel/maidlab/api/matching/service/MatchingServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/matching/service/MatchingServiceImpl.java
@@ -90,10 +90,17 @@ public class MatchingServiceImpl implements MatchingService {
 	private String extractGuFromAddress(String address) {
 		// "구" 단위 추출 (예: "서울시 강남구 역삼동" -> "강남구")
 		// 단위를 바꾸고 싶을때는 filter의 endsWith 만 바꾸면 됨
-		return Arrays.stream(address.split(" "))
-			.filter(s -> s.endsWith("구"))
-			.findFirst()
-			.orElseThrow(() -> new BaseException(ResponseType.WRONG_ADDRESS));
+		if(address.startsWith("서"))
+			return Arrays.stream(address.split(" "))
+				.filter(s -> s.endsWith("구"))
+				.findFirst()
+				.orElseThrow(() -> new BaseException(ResponseType.WRONG_ADDRESS));
+		//서울시가 아닌경우 시 단위로 나누게 함
+		else
+			return Arrays.stream(address.split(" "))
+				.filter(s -> s.endsWith("시"))
+				.findFirst()
+				.orElseThrow(() -> new BaseException(ResponseType.WRONG_ADDRESS));
 	}
 
 }

--- a/common/src/main/java/kernel/maidlab/common/entity/consumer/Consumer.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/consumer/Consumer.java
@@ -67,9 +67,6 @@ public class Consumer extends TimeBase implements UserBase {
 	@Column(name = "is_deleted", nullable = false)
 	private Boolean isDeleted;
 
-	@OneToMany
-	private List<ManagerPreference> preferences = new ArrayList<>();
-
 	private Consumer(String phoneNumber,String password, String name, Gender gender, LocalDate birth) {
 		this.phoneNumber = phoneNumber;
 		this.password = password;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#179

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

블랙 리스트에 있는 매니저를 제외하고, 이전에 서비스를 받았던 매니저, 선호 매니저를 조회할 수 있는 api 추가

이전서비스 매니저는 availableManagerDto, 선호 매니저는 likedManagerDto를 응답dto로 하였습니다.

### 스크린샷 (선택)




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

위에 적힌대로 dto의 차이때문에 이전 서비스 매니저는 서비스지역을 보여주지 않는데, 이전에 서비스를 받았던 매니저도 서비스지역을 보여주는게 맞을까요
