### PR TITLE
Refactor  consumer 프로필 등록 , 수정 api 분리

### DIFF
--- a/admin/src/main/java/kernel/maidlab/admin/consumer/controller/AdminConsumerApi.java
+++ b/admin/src/main/java/kernel/maidlab/admin/consumer/controller/AdminConsumerApi.java
@@ -1,5 +1,6 @@
 package kernel.maidlab.admin.consumer.controller;
 
+import kernel.maidlab.common.dto.consumer.response.AdminConsumerProfileResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,5 +29,5 @@ public interface AdminConsumerApi {
 	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "조회 성공 (SU)"),
 		@ApiResponse(responseCode = "401", description = "Authorization failed (AF)"),
 		@ApiResponse(responseCode = "500", description = "Database error (DBE)")})
-	ResponseEntity<ResponseDto<ConsumerProfileResponseDto>> getConsumer(@PathVariable("consumerId") Long consumerId);
+	ResponseEntity<ResponseDto<AdminConsumerProfileResponseDto>> getConsumer(@PathVariable("consumerId") Long consumerId);
 }

--- a/admin/src/main/java/kernel/maidlab/admin/consumer/controller/AdminConsumerController.java
+++ b/admin/src/main/java/kernel/maidlab/admin/consumer/controller/AdminConsumerController.java
@@ -1,5 +1,6 @@
 package kernel.maidlab.admin.consumer.controller;
 
+import kernel.maidlab.common.dto.consumer.response.AdminConsumerProfileResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,7 +33,7 @@ public class AdminConsumerController implements AdminConsumerApi {
 
 	@GetMapping("/{consumerId}")
 	@Override
-	public ResponseEntity<ResponseDto<ConsumerProfileResponseDto>> getConsumer(
+	public ResponseEntity<ResponseDto<AdminConsumerProfileResponseDto>> getConsumer(
 		@PathVariable("consumerId") Long consumerId) {
 		return ResponseDto.success(ResponseType.SUCCESS, adminConsumerService.getConsumerProfileById((Long)consumerId));
 	}

--- a/admin/src/main/java/kernel/maidlab/admin/consumer/service/AdminConsumerService.java
+++ b/admin/src/main/java/kernel/maidlab/admin/consumer/service/AdminConsumerService.java
@@ -1,5 +1,6 @@
 package kernel.maidlab.admin.consumer.service;
 
+import kernel.maidlab.common.dto.consumer.response.AdminConsumerProfileResponseDto;
 import org.springframework.data.domain.Page;
 
 import kernel.maidlab.common.dto.consumer.response.ConsumerListResponseDto;
@@ -9,5 +10,5 @@ public interface AdminConsumerService {
 	// 관리자용 전체조회로직
 	Page<ConsumerListResponseDto> getConsumerBypage(int page, int size);
 
-	ConsumerProfileResponseDto getConsumerProfileById(Long id);
+	AdminConsumerProfileResponseDto getConsumerProfileById(Long id);
 }

--- a/admin/src/main/java/kernel/maidlab/admin/consumer/service/AdminConsumerServiceImpl.java
+++ b/admin/src/main/java/kernel/maidlab/admin/consumer/service/AdminConsumerServiceImpl.java
@@ -1,5 +1,6 @@
 package kernel.maidlab.admin.consumer.service;
 
+import kernel.maidlab.common.dto.consumer.response.AdminConsumerProfileResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -31,11 +32,11 @@ public class AdminConsumerServiceImpl implements AdminConsumerService{
 	}
 
 	@Override
-	public ConsumerProfileResponseDto getConsumerProfileById(Long id) {
+	public AdminConsumerProfileResponseDto getConsumerProfileById(Long id) {
 		Consumer consumer = adminConsumerRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-		return ConsumerProfileResponseDto.builder()
+		return AdminConsumerProfileResponseDto.builder()
 			.profileImage(consumer.getProfileImage())
 			.phoneNumber(consumer.getPhoneNumber())
 			.name(consumer.getName())

--- a/api/src/main/java/kernel/maidlab/api/consumer/controller/ConsumerController.java
+++ b/api/src/main/java/kernel/maidlab/api/consumer/controller/ConsumerController.java
@@ -1,15 +1,13 @@
 package kernel.maidlab.api.consumer.controller;
 
-import kernel.maidlab.common.entity.consumer.Consumer;
 import kernel.maidlab.common.dto.consumer.ConsumerMyPageDto;
 import kernel.maidlab.common.dto.consumer.request.ConsumerProfileRequestDto;
+import kernel.maidlab.common.dto.consumer.request.ConsumerProfileUpdateRequestDto;
 import kernel.maidlab.common.dto.consumer.response.ConsumerProfileResponseDto;
 import kernel.maidlab.api.consumer.service.ConsumerService;
-import kernel.maidlab.api.auth.jwt.JwtFilter;
 import kernel.maidlab.common.dto.ResponseDto;
 
 import jakarta.servlet.http.HttpServletRequest;
-import kernel.maidlab.common.enums.ResponseType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -39,14 +37,25 @@ public class ConsumerController {
 		return ResponseDto.success(responseDto);
 	}
 
-	@PatchMapping("/profile")
-	public ResponseEntity<ResponseDto<Void>> updateProfile(
+	@PostMapping("/profile")
+	public ResponseEntity<ResponseDto<Void>> createProfile(
 		@Validated @RequestBody ConsumerProfileRequestDto consumerProfileRequestDto,
 		HttpServletRequest req) {
 
-		consumerService.updateConsumerProfile(consumerProfileRequestDto, req);
+		consumerService.createConsumerProfile(consumerProfileRequestDto, req);
 		return ResponseDto.success();
 	}
+
+	@PatchMapping("/profile")
+	public ResponseEntity<ResponseDto<Void>> updateProfile(
+			@Validated @RequestBody ConsumerProfileUpdateRequestDto consumerProfileUpdateRequestDto,
+			HttpServletRequest req
+	){
+		log.info("consumerProfileUpdateRequestDto = {}", consumerProfileUpdateRequestDto);
+		consumerService.updateConsumerProfile(consumerProfileUpdateRequestDto, req);
+		return ResponseDto.success();
+	}
+
 
 	@GetMapping("/likes")
 	public ResponseEntity<ResponseDto<Object>> getLikes(HttpServletRequest req) {

--- a/api/src/main/java/kernel/maidlab/api/consumer/service/ConsumerService.java
+++ b/api/src/main/java/kernel/maidlab/api/consumer/service/ConsumerService.java
@@ -8,6 +8,7 @@ import kernel.maidlab.api.consumer.repository.ManagerPreferenceRepositoryCustom;
 import kernel.maidlab.api.manager.repository.ManagerRepository;
 import kernel.maidlab.common.dto.consumer.ConsumerMyPageDto;
 import kernel.maidlab.common.dto.consumer.request.ConsumerProfileRequestDto;
+import kernel.maidlab.common.dto.consumer.request.ConsumerProfileUpdateRequestDto;
 import kernel.maidlab.common.dto.consumer.response.BlackListedManagerResponseDto;
 import kernel.maidlab.common.dto.consumer.response.ConsumerProfileResponseDto;
 import kernel.maidlab.common.dto.consumer.response.LikedManagerResponseDto;
@@ -47,7 +48,7 @@ public class ConsumerService {
 		return ConsumerProfileResponseDto.getInstance(consumer);
 	}
 
-	public void updateConsumerProfile(
+	public void createConsumerProfile(
 			ConsumerProfileRequestDto consumerProfileRequestDto,
 			HttpServletRequest req)
 	{
@@ -57,9 +58,19 @@ public class ConsumerService {
 		String address = consumerProfileRequestDto.getAddress();
 		String detailAddress = consumerProfileRequestDto.getDetailAddress();
 
-		consumer.updateProfile(profileImage, address, detailAddress);
+		consumer.createProfile(profileImage, address, detailAddress);
 		consumerRepository.save(consumer);
 	}
+
+	public void updateConsumerProfile(
+			ConsumerProfileUpdateRequestDto consumerProfileUpdateRequestDto,
+			HttpServletRequest req){
+
+		Consumer consumer = getConsumer(req);
+		consumer.updateProfile(consumerProfileUpdateRequestDto);
+		consumerRepository.save(consumer);
+	}
+
 
 	// 찜한 매니저 조회
 	@Transactional(readOnly = true)

--- a/common/src/main/java/kernel/maidlab/common/dto/consumer/request/ConsumerProfileUpdateRequestDto.java
+++ b/common/src/main/java/kernel/maidlab/common/dto/consumer/request/ConsumerProfileUpdateRequestDto.java
@@ -1,0 +1,18 @@
+package kernel.maidlab.common.dto.consumer.request;
+
+import kernel.maidlab.common.enums.Gender;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class ConsumerProfileUpdateRequestDto {
+
+    private String profileImage;
+    private String name;
+    private Gender gender;
+    private LocalDate birth;
+    private String address;
+    private String detailAddress;
+
+}

--- a/common/src/main/java/kernel/maidlab/common/dto/consumer/response/AdminConsumerProfileResponseDto.java
+++ b/common/src/main/java/kernel/maidlab/common/dto/consumer/response/AdminConsumerProfileResponseDto.java
@@ -1,0 +1,40 @@
+package kernel.maidlab.common.dto.consumer.response;
+
+import kernel.maidlab.common.entity.consumer.Consumer;
+import kernel.maidlab.common.entity.manager.Manager;
+import kernel.maidlab.common.enums.Gender;
+import kernel.maidlab.common.enums.Region;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AdminConsumerProfileResponseDto {
+
+    private String profileImage;
+    private String phoneNumber;
+    private String name;
+    private LocalDate birth;
+    private Gender gender;
+    private String address;
+    private String detailAddress;
+
+
+    public static AdminConsumerProfileResponseDto getInstance(Consumer consumer){
+
+        return new AdminConsumerProfileResponseDto(
+                consumer.getProfileImage(),
+                consumer.getPhoneNumber(),
+                consumer.getName(),
+                consumer.getBirth(),
+                consumer.getGender(),
+                consumer.getAddress(),
+                consumer.getDetailAddress()
+        );
+    }
+}

--- a/common/src/main/java/kernel/maidlab/common/dto/consumer/response/ConsumerProfileResponseDto.java
+++ b/common/src/main/java/kernel/maidlab/common/dto/consumer/response/ConsumerProfileResponseDto.java
@@ -16,7 +16,6 @@ import java.time.LocalDate;
 public class ConsumerProfileResponseDto {
 
     private String profileImage;
-    private String phoneNumber;
     private String name;
     private LocalDate birth;
     private Gender gender;
@@ -28,7 +27,6 @@ public class ConsumerProfileResponseDto {
 
         return new ConsumerProfileResponseDto(
                 consumer.getProfileImage(),
-                consumer.getPhoneNumber(),
                 consumer.getName(),
                 consumer.getBirth(),
                 consumer.getGender(),

--- a/common/src/main/java/kernel/maidlab/common/entity/consumer/Consumer.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/consumer/Consumer.java
@@ -1,6 +1,9 @@
 package kernel.maidlab.common.entity.consumer;
 
 import jakarta.persistence.*;
+import jakarta.servlet.http.HttpServletRequest;
+import kernel.maidlab.common.dto.consumer.request.ConsumerProfileRequestDto;
+import kernel.maidlab.common.dto.consumer.request.ConsumerProfileUpdateRequestDto;
 import kernel.maidlab.common.entity.base.Base;
 import kernel.maidlab.common.entity.base.TimeBase;
 import kernel.maidlab.common.entity.base.UserBase;
@@ -67,9 +70,6 @@ public class Consumer extends TimeBase implements UserBase {
 	@Column(name = "is_deleted", nullable = false)
 	private Boolean isDeleted;
 
-	@OneToMany
-	private List<ManagerPreference> preferences = new ArrayList<>();
-
 	private Consumer(String phoneNumber,String password, String name, Gender gender, LocalDate birth) {
 		this.phoneNumber = phoneNumber;
 		this.password = password;
@@ -105,10 +105,19 @@ public class Consumer extends TimeBase implements UserBase {
 
 	}
 
-	public void updateProfile(String profileImage, String address, String detailAddress){
+	public void createProfile(String profileImage, String address, String detailAddress){
 		this.profileImage = profileImage;
 		this.address = address;
 		this.detailAddress = detailAddress;
+	}
+
+	public void updateProfile(ConsumerProfileUpdateRequestDto consumerProfileUpdateRequestDto){
+		this.profileImage = consumerProfileUpdateRequestDto.getProfileImage();
+		this.name = consumerProfileUpdateRequestDto.getName();
+		this.gender = consumerProfileUpdateRequestDto.getGender();
+		this.birth = consumerProfileUpdateRequestDto.getBirth();
+		this.address = consumerProfileUpdateRequestDto.getAddress();
+		this.detailAddress = consumerProfileUpdateRequestDto.getDetailAddress();
 	}
 
 	@PrePersist


### PR DESCRIPTION
## #️⃣연관된 이슈

> #177 

## 📝작업 내용

- consumer 프로필 둥록, 수정 api 분리
- 수요자 프로필 dto 폰넘버 삭제
- 수요자 프로필 수정으로 인해 새로운 admin이 수요자 프로필 조회용 dto 만듦   

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
