### PR TITLE
refactor: 프론트 MyPage에서 소설타입을 받기 위해 ConsumerMyPageDto 변경

### DIFF
--- a/common/src/main/java/kernel/maidlab/common/dto/consumer/ConsumerMyPageDto.java
+++ b/common/src/main/java/kernel/maidlab/common/dto/consumer/ConsumerMyPageDto.java
@@ -1,31 +1,26 @@
 package kernel.maidlab.common.dto.consumer;
 
 import kernel.maidlab.common.entity.consumer.Consumer;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import kernel.maidlab.common.enums.SocialType;
+import lombok.*;
 
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ConsumerMyPageDto {
     private String name;
     private int point;
     private String profileImage;
-
-    @Builder
-    public ConsumerMyPageDto(String name, int point, String profileImage) {
-        this.name = name;
-        this.point = point;
-        this.profileImage = profileImage;
-    }
+    private SocialType socialType;
 
     public static ConsumerMyPageDto getInstance(Consumer consumer){
 
         return new ConsumerMyPageDto(
                 consumer.getName(),
                 consumer.getPoint(),
-                consumer.getProfileImage()
+                consumer.getProfileImage(),
+                consumer.getSocialType()
         );
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #177 

## 📝작업 내용

프론트 MyPage에서 소셜 로그인한 사용자 구분을 위해 socialType을 받을 수 있도록
ConsumerMyPageDto에 socialType 멤버를 추가

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
