### PR TITLE
feat : 수요자 및 매니저 예약 페이지 필터링, 정렬 및 페이징 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ out/
 
 ### env ###
 .env
+
+CLAUDE.md
+
+*.log

--- a/api/src/main/java/kernel/maidlab/api/reservation/controller/ReservationApi.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/controller/ReservationApi.java
@@ -159,4 +159,11 @@ public interface ReservationApi {
 		@RequestParam(defaultValue = "reservationDate") String sortBy,
 		@RequestParam(defaultValue = "DESC") String sortOrder,
 		HttpServletRequest request);
+
+	ResponseEntity<ResponseDto<org.springframework.data.domain.Page<ReservationResponseDto>>> getManagerReservationsWithPaging(
+			@RequestParam(required = false) String status,
+			@RequestParam(defaultValue = "0") int page,
+			@RequestParam(defaultValue = "5") int size,
+			@RequestParam(defaultValue = "DESC") String sortOrder,
+			HttpServletRequest request);
 }

--- a/api/src/main/java/kernel/maidlab/api/reservation/controller/ReservationApi.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/controller/ReservationApi.java
@@ -3,7 +3,7 @@ package kernel.maidlab.api.reservation.controller;
 import java.time.LocalDate;
 import java.util.List;
 
-
+import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -143,4 +143,20 @@ public interface ReservationApi {
 	})
 	ResponseEntity<ResponseDto<WeeklySettlementResponseDto>> getWeeklySettlements(HttpServletRequest request,
 		@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate);
+
+	@Operation(summary = "소비자 예약 조회 (페이징)", description = "소비자의 예약을 페이징, 필터링, 정렬하여 조회합니다. MATCHED 상태가 PAID보다 우선순위가 높습니다.", security = @SecurityRequirement(name = "JWT"))
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "Success (SU)", content = @Content(schema = @Schema(implementation = Page.class))),
+		@ApiResponse(responseCode = "400", description = "Validation failed (VF) - 잘못된 파라미터"),
+		@ApiResponse(responseCode = "401", description = "Authorization failed / Login failed (AF | LF)"),
+		@ApiResponse(responseCode = "403", description = "Do not have permission (NP)"),
+		@ApiResponse(responseCode = "500", description = "Database error (DBE)")
+	})
+	ResponseEntity<ResponseDto<Page<ReservationResponseDto>>> getConsumerReservationsWithPaging(
+		@RequestParam(required = false) String status,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "5") int size,
+		@RequestParam(defaultValue = "reservationDate") String sortBy,
+		@RequestParam(defaultValue = "DESC") String sortOrder,
+		HttpServletRequest request);
 }

--- a/api/src/main/java/kernel/maidlab/api/reservation/controller/ReservationController.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/controller/ReservationController.java
@@ -51,6 +51,23 @@ public class ReservationController implements ReservationApi {
 		return ResponseDto.success(ResponseType.SUCCESS, response);
 	}
 
+	@GetMapping("/consumer")
+	public ResponseEntity<ResponseDto<org.springframework.data.domain.Page<ReservationResponseDto>>> getConsumerReservationsWithPaging(
+			@RequestParam(required = false) String status,
+			@RequestParam(defaultValue = "0") int page,
+			@RequestParam(defaultValue = "5") int size,
+			@RequestParam(defaultValue = "reservationDate") String sortBy,
+			@RequestParam(defaultValue = "DESC") String sortOrder,
+			HttpServletRequest request) {
+		log.info("Get consumer reservations with paging - status: {}, page: {}, size: {}, sortBy: {}, sortOrder: {}", 
+			status, page, size, sortBy, sortOrder);
+		
+		org.springframework.data.domain.Page<ReservationResponseDto> response = 
+			reservationService.getConsumerReservationsWithPaging(status, page, size, sortBy, sortOrder, request);
+		
+		return ResponseDto.success(ResponseType.SUCCESS, response);
+	}
+
 	@GetMapping("/{reservationId}")
 	@Override
 	public ResponseEntity<ResponseDto<ReservationDetailResponseDto>> reservationDetail(@PathVariable Long reservationId,

--- a/api/src/main/java/kernel/maidlab/api/reservation/controller/ReservationController.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/controller/ReservationController.java
@@ -68,6 +68,22 @@ public class ReservationController implements ReservationApi {
 		return ResponseDto.success(ResponseType.SUCCESS, response);
 	}
 
+	@GetMapping("/manager")
+	public ResponseEntity<ResponseDto<org.springframework.data.domain.Page<ReservationResponseDto>>> getManagerReservationsWithPaging(
+			@RequestParam(required = false) String status,
+			@RequestParam(defaultValue = "0") int page,
+			@RequestParam(defaultValue = "5") int size,
+			@RequestParam(defaultValue = "DESC") String sortOrder,
+			HttpServletRequest request) {
+		log.info("Get manager reservations with paging - status: {}, page: {}, size: {}, sortOrder: {}", 
+			status, page, size, sortOrder);
+		
+		org.springframework.data.domain.Page<ReservationResponseDto> response = 
+			reservationService.getManagerReservationsWithPaging(status, page, size, sortOrder, request);
+		
+		return ResponseDto.success(ResponseType.SUCCESS, response);
+	}
+
 	@GetMapping("/{reservationId}")
 	@Override
 	public ResponseEntity<ResponseDto<ReservationDetailResponseDto>> reservationDetail(@PathVariable Long reservationId,

--- a/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustom.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustom.java
@@ -5,7 +5,10 @@ import java.util.Optional;
 
 import kernel.maidlab.common.dto.reservation.response.ReservationDetailResponseDto;
 import kernel.maidlab.common.dto.reservation.response.ReservationResponseDto;
+import kernel.maidlab.common.enums.Status;
 import kernel.maidlab.common.enums.UserType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ReservationRepositoryCustom {
 	List<ReservationResponseDto> findAllWithReviewByConsumerId(Long consumerId);
@@ -14,5 +17,6 @@ public interface ReservationRepositoryCustom {
 
 	ReservationDetailResponseDto findDetailReservationByIdAndUser(Long reservationId, Long userId, UserType userType);
 
+	Page<ReservationResponseDto> findConsumerReservationsWithPaging(Long consumerId, Status status, Pageable pageable);
 
 }

--- a/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustom.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustom.java
@@ -18,5 +18,7 @@ public interface ReservationRepositoryCustom {
 	ReservationDetailResponseDto findDetailReservationByIdAndUser(Long reservationId, Long userId, UserType userType);
 
 	Page<ReservationResponseDto> findConsumerReservationsWithPaging(Long consumerId, Status status, Pageable pageable);
+	
+	Page<ReservationResponseDto> getManagerReservationsWithPaging(Long managerId, String status, Pageable pageable);
 
 }

--- a/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustomImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustomImpl.java
@@ -1,5 +1,7 @@
 package kernel.maidlab.api.reservation.repository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +16,8 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -186,6 +190,86 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 		} else {
 			// 기본 정렬: createdAt DESC
 			orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, reservation.createdAt));
+		}
+		
+		JPAQuery<ReservationResponseDto> query = queryFactory
+			.select(Projections.constructor(ReservationResponseDto.class,
+				reservation.id,
+				reservation.status,
+				reservation.serviceDetailType.serviceType.stringValue(),
+				reservation.serviceDetailType.serviceDetailType,
+				reservation.reservationDate.stringValue(),
+				reservation.startTime.stringValue().substring(11, 16),
+				reservation.endTime.stringValue().substring(11, 16),
+				JPAExpressions.selectOne().from(review).where(review.reservationId.eq(reservation.id)).exists(),
+				reservation.totalPrice))
+			.from(reservation)
+			.join(reservation.serviceDetailType, serviceDetailType)
+			.where(finalCondition)
+			.orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]));
+		
+		Long totalCount = queryFactory
+			.select(reservation.count())
+			.from(reservation)
+			.join(reservation.serviceDetailType, serviceDetailType)
+			.where(finalCondition)
+			.fetchOne();
+		
+		long total = totalCount != null ? totalCount : 0L;
+		
+		List<ReservationResponseDto> content = query
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+		
+		return new PageImpl<>(content, pageable, total);
+	}
+
+	@Override
+	public Page<ReservationResponseDto> getManagerReservationsWithPaging(Long managerId, String status, Pageable pageable) {
+		BooleanExpression baseCondition = reservation.managerId.eq(managerId);
+		BooleanExpression statusCondition = null;
+		
+		// 상태별 조건 처리
+		if ("TODAY".equals(status)) {
+			// 오늘 날짜 조건 (LocalDate와 LocalDateTime 비교를 위해 날짜 범위로 조건 생성)
+			LocalDate today = LocalDate.now();
+			LocalDateTime startOfDay = today.atStartOfDay();
+			LocalDateTime endOfDay = today.atTime(23, 59, 59);
+			statusCondition = reservation.reservationDate.goe(startOfDay).and(reservation.reservationDate.loe(endOfDay));
+		} else if ("PAID".equals(status)) {
+			// PAID와 MATCHED 상태 함께 조회
+			statusCondition = reservation.status.eq(Status.PAID).or(reservation.status.eq(Status.MATCHED));
+		} else if ("WORKING".equals(status)) {
+			statusCondition = reservation.status.eq(Status.WORKING);
+		} else if ("COMPLETED".equals(status)) {
+			statusCondition = reservation.status.eq(Status.COMPLETED);
+		}
+		
+		BooleanExpression finalCondition = statusCondition != null ? baseCondition.and(statusCondition) : baseCondition;
+		
+		// 정렬 조건 처리
+		List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+		
+		if ("TODAY".equals(status)) {
+			// TODAY 요청시 상태별 우선순위 정렬 (WORKING > PAID > 나머지)
+			NumberExpression<Integer> statusPriority = new CaseBuilder()
+				.when(reservation.status.eq(Status.WORKING)).then(0)
+				.when(reservation.status.eq(Status.PAID)).then(1)
+				.otherwise(2);
+			orderSpecifiers.add(new OrderSpecifier<>(Order.ASC, statusPriority));
+		}
+		
+		// reservationDate 기준 정렬
+		Order direction = pageable.getSort().isSorted() && 
+			pageable.getSort().getOrderFor("reservationDate") != null &&
+			pageable.getSort().getOrderFor("reservationDate").isAscending() ? Order.ASC : Order.DESC;
+		
+		orderSpecifiers.add(new OrderSpecifier<>(direction, reservation.reservationDate));
+		
+		// PAID 상태일 때는 시간까지 고려한 정렬
+		if ("PAID".equals(status)) {
+			orderSpecifiers.add(new OrderSpecifier<>(direction, reservation.startTime));
 		}
 		
 		JPAQuery<ReservationResponseDto> query = queryFactory

--- a/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustomImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustomImpl.java
@@ -1,13 +1,21 @@
 package kernel.maidlab.api.reservation.repository;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import kernel.maidlab.common.dto.reservation.response.ReservationDetailResponseDto;
@@ -19,6 +27,7 @@ import kernel.maidlab.common.entity.reservation.QReservation;
 import kernel.maidlab.common.entity.reservation.QReview;
 import kernel.maidlab.common.entity.reservation.QServiceDetailType;
 import kernel.maidlab.common.enums.ResponseType;
+import kernel.maidlab.common.enums.Status;
 import kernel.maidlab.common.enums.UserType;
 import kernel.maidlab.common.exception.custom.ReservationException;
 import lombok.RequiredArgsConstructor;
@@ -64,7 +73,6 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 
 	@Override
 	public ReservationDetailResponseDto findDetailReservationByIdAndUser(Long reservationId, Long userId, UserType userType) {
-
 
 		// 사용자 일치 조건 (권한 체크)
 		BooleanExpression userCondition = (userType == UserType.MANAGER)
@@ -142,6 +150,75 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 			.specialRequest(first.get(reservation.specialRequest))
 			.totalPrice(first.get(reservation.totalPrice))
 			.build();
+	}
+
+	@Override
+	public Page<ReservationResponseDto> findConsumerReservationsWithPaging(Long consumerId, Status status, Pageable pageable) {
+		BooleanExpression baseCondition = reservation.consumerId.eq(consumerId);
+		
+		BooleanExpression statusCondition = status != null ? reservation.status.eq(status) : null;
+		BooleanExpression finalCondition = statusCondition != null ? baseCondition.and(statusCondition) : baseCondition;
+		
+		// Pageable의 Sort 정보를 QueryDSL OrderSpecifier로 변환
+		List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+		
+		if (pageable.getSort().isSorted()) {
+			for (org.springframework.data.domain.Sort.Order sortOrder : pageable.getSort()) {
+				Order direction = sortOrder.isAscending() ? Order.ASC : Order.DESC;
+				switch (sortOrder.getProperty()) {
+					case "createdAt":
+						orderSpecifiers.add(new OrderSpecifier<>(direction, reservation.createdAt));
+						break;
+					case "reservationDate":
+						orderSpecifiers.add(new OrderSpecifier<>(direction, reservation.reservationDate));
+						break;
+					case "totalPrice":
+						orderSpecifiers.add(new OrderSpecifier<>(direction, reservation.totalPrice));
+						break;
+					case "startTime":
+						orderSpecifiers.add(new OrderSpecifier<>(direction, reservation.startTime));
+						break;
+					default:
+						orderSpecifiers.add(new OrderSpecifier<>(direction, reservation.createdAt));
+						break;
+				}
+			}
+		} else {
+			// 기본 정렬: createdAt DESC
+			orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, reservation.createdAt));
+		}
+		
+		JPAQuery<ReservationResponseDto> query = queryFactory
+			.select(Projections.constructor(ReservationResponseDto.class,
+				reservation.id,
+				reservation.status,
+				reservation.serviceDetailType.serviceType.stringValue(),
+				reservation.serviceDetailType.serviceDetailType,
+				reservation.reservationDate.stringValue(),
+				reservation.startTime.stringValue().substring(11, 16),
+				reservation.endTime.stringValue().substring(11, 16),
+				JPAExpressions.selectOne().from(review).where(review.reservationId.eq(reservation.id)).exists(),
+				reservation.totalPrice))
+			.from(reservation)
+			.join(reservation.serviceDetailType, serviceDetailType)
+			.where(finalCondition)
+			.orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]));
+		
+		Long totalCount = queryFactory
+			.select(reservation.count())
+			.from(reservation)
+			.join(reservation.serviceDetailType, serviceDetailType)
+			.where(finalCondition)
+			.fetchOne();
+		
+		long total = totalCount != null ? totalCount : 0L;
+		
+		List<ReservationResponseDto> content = query
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+		
+		return new PageImpl<>(content, pageable, total);
 	}
 
 }

--- a/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationService.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationService.java
@@ -40,4 +40,6 @@ public interface ReservationService {
 	WeeklySettlementResponseDto getWeeklySettlements(HttpServletRequest request, LocalDate startDate);
 
 	Page<ReservationResponseDto> getConsumerReservationsWithPaging(String status, int page, int size, String sortBy, String sortOrder, HttpServletRequest request);
+
+	Page<ReservationResponseDto> getManagerReservationsWithPaging(String status, int page, int size, String sortOrder, HttpServletRequest request);
 }

--- a/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationService.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationService.java
@@ -3,6 +3,8 @@ package kernel.maidlab.api.reservation.service;
 import java.time.LocalDate;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+
 import jakarta.servlet.http.HttpServletRequest;
 import kernel.maidlab.common.dto.reservation.request.PaymentRequestDto;
 import kernel.maidlab.common.dto.reservation.request.CheckInOutRequestDto;
@@ -36,4 +38,6 @@ public interface ReservationService {
 	void registerReview(ReviewRegisterRequestDto dto, HttpServletRequest request);
 
 	WeeklySettlementResponseDto getWeeklySettlements(HttpServletRequest request, LocalDate startDate);
+
+	Page<ReservationResponseDto> getConsumerReservationsWithPaging(String status, int page, int size, String sortBy, String sortOrder, HttpServletRequest request);
 }

--- a/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
@@ -4,12 +4,14 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import kernel.maidlab.api.reservation.repository.*;
 import kernel.maidlab.common.entity.reservation.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -121,7 +123,7 @@ public class ReservationServiceImpl implements ReservationService {
 			}
 		}
 	}
-
+	// 이전 예약 전체 조회 api
 	@Override
 	public List<ReservationResponseDto> allReservations(HttpServletRequest request) {
 		UserType userType = authUtil.getUserType(request);
@@ -135,6 +137,37 @@ public class ReservationServiceImpl implements ReservationService {
 
 		}
 	}
+
+	// 고객 맞춤 예약 내역 페이징 및 상태별 필터링
+    @Override
+    public Page<ReservationResponseDto> getConsumerReservationsWithPaging(String status, int page, int size, String sortBy, String sortOrder, HttpServletRequest request) {
+        Consumer consumer = authUtil.getConsumer(request);
+        Long consumerId = consumer.getId();
+
+        if (size > 50) {
+            size = 50;
+        }
+
+        Set<String> allowedSortFields = new HashSet<>(Arrays.asList("createdAt", "reservationDate", "totalPrice", "completedAt", "startTime"));
+        if (!allowedSortFields.contains(sortBy)) {
+            sortBy = "createdAt";
+        }
+
+        Status statusEnum = null;
+        if (status != null && !status.trim().isEmpty()) {
+            try {
+                statusEnum = Status.valueOf(status.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new ReservationException(ResponseType.VALIDATION_FAILED);
+            }
+        }
+
+        Sort.Direction direction = "ASC".equalsIgnoreCase(sortOrder) ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Sort sort = Sort.by(direction, sortBy);
+        Pageable pageable = PageRequest.of(page, size, sort);
+
+        return reservationRepository.findConsumerReservationsWithPaging(consumerId, statusEnum, pageable);
+    }
 
 	@Override
 	public ReservationDetailResponseDto getReservationDetail(Long reservationId, HttpServletRequest request) {

--- a/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
@@ -169,6 +169,22 @@ public class ReservationServiceImpl implements ReservationService {
         return reservationRepository.findConsumerReservationsWithPaging(consumerId, statusEnum, pageable);
     }
 
+    @Override
+    public Page<ReservationResponseDto> getManagerReservationsWithPaging(String status, int page, int size, String sortOrder, HttpServletRequest request) {
+        Manager manager = authUtil.getManager(request);
+        Long managerId = manager.getId();
+
+        if (size > 50) {
+            size = 50;
+        }
+
+        Sort.Direction direction = "ASC".equalsIgnoreCase(sortOrder) ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Sort sort = Sort.by(direction, "reservationDate");
+        Pageable pageable = PageRequest.of(page, size, sort);
+
+        return reservationRepository.getManagerReservationsWithPaging(managerId, status, pageable);
+    }
+
 	@Override
 	public ReservationDetailResponseDto getReservationDetail(Long reservationId, HttpServletRequest request) {
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#200 

## 📝작업 내용

- 매니저, 수요자 각각 status 별로의 필터링 처리 및 정렬 처리
- 한페이지당 5개 페이징 서버사이드 렌더링 구현

### 스크린샷 (선택)




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
