### PR TITLE
point 결제, 충전 api 구현 

### DIFF
--- a/api/src/main/java/kernel/maidlab/api/point/controller/PointApi.java
+++ b/api/src/main/java/kernel/maidlab/api/point/controller/PointApi.java
@@ -1,0 +1,34 @@
+package kernel.maidlab.api.point.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import kernel.maidlab.common.dto.ResponseDto;
+import kernel.maidlab.common.dto.point.request.PointChargeRequestDto;
+import kernel.maidlab.common.dto.point.request.PointRecordRequestDto;
+import kernel.maidlab.common.dto.point.response.PageResponseDto;
+import kernel.maidlab.common.dto.point.response.PointRecordResponseDto;
+import kernel.maidlab.common.dto.point.response.PointResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Point", description = "포인트 관련 API")
+public interface PointApi {
+    @Operation(summary = "수요자 현재 포인트 조회", description = "현재 로그인한 수요자의 사용 가능 포인트를 조회합니다.")
+    ResponseEntity<ResponseDto<PointResponseDto>> getPoint(
+            @Parameter(hidden = true) HttpServletRequest request
+    );
+
+    @Operation(summary = "수요자 포인트 이력 조회", description = "현재 로그인한 수요자의 포인트 사용 및 적립 이력을 조회합니다.")
+    ResponseEntity<ResponseDto<PageResponseDto<PointRecordResponseDto>>> getPointRecord(
+            @Parameter(hidden = true) HttpServletRequest request,
+            @RequestBody PointRecordRequestDto pointRecordRequestDto
+    );
+
+    @Operation(summary = "포인트 충전", description = "수요자가 포인트를 충전합니다.")
+    ResponseEntity<ResponseDto<String>> chargePoint(
+            @Parameter(hidden = true) HttpServletRequest request,
+            @RequestBody PointChargeRequestDto pointChargeRequestDto
+    );
+}

--- a/api/src/main/java/kernel/maidlab/api/point/controller/PointController.java
+++ b/api/src/main/java/kernel/maidlab/api/point/controller/PointController.java
@@ -3,6 +3,7 @@ package kernel.maidlab.api.point.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import kernel.maidlab.api.point.service.PointService;
 import kernel.maidlab.common.dto.ResponseDto;
+import kernel.maidlab.common.dto.point.request.PointChargeRequestDto;
 import kernel.maidlab.common.dto.point.request.PointRecordRequestDto;
 import kernel.maidlab.common.dto.point.response.PageResponseDto;
 import kernel.maidlab.common.dto.point.response.PointRecordResponseDto;
@@ -12,8 +13,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/point")
 @RequiredArgsConstructor
+@RequestMapping("/api/point")
 public class PointController {
 
     private final PointService pointService;
@@ -34,5 +35,15 @@ public class PointController {
         PageResponseDto<PointRecordResponseDto> pointRecordList = pointService.getPointRecordList(request, pointRecordRequestDto);
 
         return ResponseDto.success(pointRecordList);
+    }
+
+    // 포인트 충전
+    @PostMapping("/charge")
+    public ResponseEntity<ResponseDto<String>> chargePoint (
+            HttpServletRequest request,
+            @RequestBody PointChargeRequestDto pointChargeRequestDto
+    ){
+        pointService.chargePoint(request, pointChargeRequestDto);
+        return ResponseDto.success("충전이 완료 되었습니다.");
     }
 }

--- a/api/src/main/java/kernel/maidlab/api/point/repository/PointRepositoryCustom.java
+++ b/api/src/main/java/kernel/maidlab/api/point/repository/PointRepositoryCustom.java
@@ -15,6 +15,4 @@ public interface PointRepositoryCustom {
             String pointType,
             Pageable pageable
     );
-    
-    Integer findUsageAmountByReservationAndConsumer(Long reservationId, Long consumerId);
 }

--- a/api/src/main/java/kernel/maidlab/api/point/repository/PointRepositoryCustomImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/point/repository/PointRepositoryCustomImpl.java
@@ -80,23 +80,6 @@ public class PointRepositoryCustomImpl implements PointRepositoryCustom{
         return new PageImpl<>(content, pageable, total);
     }
 
-    @Override
-    public Integer findUsageAmountByReservationAndConsumer(Long reservationId, Long consumerId) {
-        QPoint point = QPoint.point;
-        Integer usageAmount = queryFactory
-                .select(point.amount.sum())
-                .from(point)
-                .where(point.reservation.id.eq(reservationId)
-                        .and(point.consumer.id.eq(consumerId))
-                        .and(point.amount.lt(0))
-                        .and(point.pointType.eq(PointType.PAYMENT))
-                )
-                .fetchOne();
-
-        return usageAmount != null ? Math.abs(usageAmount) : 0;
-    }
-
-
     private BooleanExpression eqPointType(String pointType, QPoint point) {
         if (pointType == null || pointType.equalsIgnoreCase("ALL")) {
             return null;

--- a/api/src/main/java/kernel/maidlab/api/point/service/PointService.java
+++ b/api/src/main/java/kernel/maidlab/api/point/service/PointService.java
@@ -1,6 +1,7 @@
 package kernel.maidlab.api.point.service;
 
 import jakarta.servlet.http.HttpServletRequest;
+import kernel.maidlab.common.dto.point.request.PointChargeRequestDto;
 import kernel.maidlab.common.dto.point.request.PointRecordRequestDto;
 import kernel.maidlab.common.dto.point.response.PageResponseDto;
 import kernel.maidlab.common.dto.point.response.PointRecordResponseDto;
@@ -12,4 +13,7 @@ public interface PointService {
 
     PageResponseDto<PointRecordResponseDto> getPointRecordList(HttpServletRequest request,
                                                                PointRecordRequestDto pointRecordRequestDto);
+
+    void chargePoint(HttpServletRequest request,
+                     PointChargeRequestDto pointChargeRequestDto);
 }

--- a/api/src/main/java/kernel/maidlab/api/point/service/PointServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/point/service/PointServiceImpl.java
@@ -3,11 +3,13 @@ package kernel.maidlab.api.point.service;
 import jakarta.servlet.http.HttpServletRequest;
 import kernel.maidlab.api.auth.jwt.JwtFilter;
 import kernel.maidlab.api.point.repository.PointRepository;
+import kernel.maidlab.common.dto.point.request.PointChargeRequestDto;
 import kernel.maidlab.common.dto.point.request.PointRecordRequestDto;
 import kernel.maidlab.common.dto.point.response.PageResponseDto;
 import kernel.maidlab.common.dto.point.response.PointRecordResponseDto;
 import kernel.maidlab.common.dto.point.response.PointResponseDto;
 import kernel.maidlab.common.entity.consumer.Consumer;
+import kernel.maidlab.common.entity.point.Point;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -73,4 +75,21 @@ public class PointServiceImpl implements PointService{
                 .hasNext(pointRecordsPage.hasNext())
                 .build();
     }
+
+    public void chargePoint(
+            HttpServletRequest request,
+            PointChargeRequestDto pointChargeRequestDto
+    ){
+        Consumer consumer = (Consumer) request.getAttribute(JwtFilter.CURRENT_USER_KEY);
+
+        if (pointChargeRequestDto.getChargeAmount() > 0){
+            Point chargedPoint = Point.createChargePoint(
+                    consumer,
+                    pointChargeRequestDto.getChargeAmount());
+
+            pointRepository.save(chargedPoint);
+        }
+
+    }
+
 }

--- a/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
@@ -280,12 +280,16 @@ public class ReservationServiceImpl implements ReservationService {
 		Reservation reservation = reservationRepository.findById(dto.getReservationId())
 				.orElseThrow(() -> new ReservationException(ResponseType.DATABASE_ERROR));
 
-		reservation.pay();
-
+		// 결제시 포인트 사용
+		reservation.pay(dto.getPointToUse());
 		reservationRepository.save(reservation);
 
+		// 포인트 차감
+		Point usagePoint = Point.createUsagePoint(consumer, reservation, dto.getPointToUse());
+		pointRepository.save(usagePoint);
+
 		// 포인트 적립
-		Point point = Point.createPointForPayment(consumer, reservation, reservation.getTotalPrice());
+		Point point = Point.createEarnPointOnPayment(consumer, reservation, reservation.getTotalPrice());
 		pointRepository.save(point);
 	}
 

--- a/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
@@ -281,12 +281,16 @@ public class ReservationServiceImpl implements ReservationService {
 				.orElseThrow(() -> new ReservationException(ResponseType.DATABASE_ERROR));
 
 		// 결제시 포인트 사용
-		reservation.pay(dto.getPointToUse());
-		reservationRepository.save(reservation);
+		if (dto.isPointUsed()){
+			reservation.usePoints(dto.getPointToUse());
 
-		// 포인트 차감
-		Point usagePoint = Point.createUsagePoint(consumer, reservation, dto.getPointToUse());
-		pointRepository.save(usagePoint);
+			// 포인트 차감
+			Point usagePoint = Point.createUsagePoint(consumer, reservation, dto.getPointToUse());
+			pointRepository.save(usagePoint);
+		}
+
+		reservation.pay();
+		reservationRepository.save(reservation);
 
 		// 포인트 적립
 		Point point = Point.createEarnPointOnPayment(consumer, reservation, reservation.getTotalPrice());

--- a/common/src/main/java/kernel/maidlab/common/dto/point/request/PointChargeRequestDto.java
+++ b/common/src/main/java/kernel/maidlab/common/dto/point/request/PointChargeRequestDto.java
@@ -1,0 +1,9 @@
+package kernel.maidlab.common.dto.point.request;
+
+import lombok.Getter;
+
+@Getter
+public class PointChargeRequestDto {
+    private Integer chargeAmount;
+
+}

--- a/common/src/main/java/kernel/maidlab/common/dto/reservation/request/PaymentRequestDto.java
+++ b/common/src/main/java/kernel/maidlab/common/dto/reservation/request/PaymentRequestDto.java
@@ -8,4 +8,5 @@ import lombok.NoArgsConstructor;
 public class PaymentRequestDto {
     private Long reservationId;
     private Integer pointToUse;
+    private boolean pointUsed;
 }

--- a/common/src/main/java/kernel/maidlab/common/dto/reservation/request/PaymentRequestDto.java
+++ b/common/src/main/java/kernel/maidlab/common/dto/reservation/request/PaymentRequestDto.java
@@ -7,4 +7,5 @@ import lombok.NoArgsConstructor;
 @Getter
 public class PaymentRequestDto {
     private Long reservationId;
+    private Integer pointToUse;
 }

--- a/common/src/main/java/kernel/maidlab/common/entity/point/Point.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/point/Point.java
@@ -48,29 +48,29 @@ public class Point extends TimeBase {
         return Math.max(earnedPoint, 0);
     }
 
-    public static Point createPointForPayment(Consumer consumer, Reservation  reservation, BigDecimal totalPrice){
+    public static Point createEarnPointOnPayment(Consumer consumer, Reservation  reservation, BigDecimal totalPrice){
 
         int payAmount = totalPrice.intValue();
-        Integer amount = calculateEarnedPoint(payAmount);
+        Integer earnedPoint = calculateEarnedPoint(payAmount);
 
         return new Point(
                 consumer,
                 null,  // 이벤트 없음
                 reservation,
-                amount,
+                earnedPoint,
                 PointType.PAYMENT,
                 "결제 적립 포인트"
         );
     }
 
     @Builder
-    public static Point createUsagePoint(Consumer consumer, Reservation reservation, Integer usageAmount){
+    public static Point createUsagePoint(Consumer consumer, Reservation reservation, Integer usageAmountPoint){
 
         return new Point(
                 consumer,
                 null,
                 reservation,
-                (-Math.abs(usageAmount)),
+                (-Math.abs(usageAmountPoint)),
                 PointType.PAYMENT,
                 "결제 사용 포인트"
 

--- a/common/src/main/java/kernel/maidlab/common/entity/point/Point.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/point/Point.java
@@ -47,7 +47,12 @@ public class Point extends TimeBase {
         return Math.max(earnedPoint, 0);
     }
 
-    public static Point createPaymentPoint(Consumer consumer, Reservation reservation, Integer amount, boolean isEarned) {
+    public static Point createPaymentPoint(
+            Consumer consumer,
+            Reservation reservation,
+            Integer amount,
+            boolean isEarned)
+    {
         Integer pointAmount;
         String description;
         
@@ -69,13 +74,21 @@ public class Point extends TimeBase {
         );
     }
 
-    public static Point createEarnPointOnPayment(Consumer consumer, Reservation reservation, BigDecimal totalPrice) {
+    public static Point createEarnPointOnPayment(
+            Consumer consumer,
+            Reservation reservation,
+            BigDecimal totalPrice)
+    {
         int payAmount = totalPrice.intValue();
         Integer earnedPoint = calculateEarnedPoint(payAmount);
         return createPaymentPoint(consumer, reservation, earnedPoint, true);
     }
     
-    public static Point createUsagePoint(Consumer consumer, Reservation reservation, Integer usageAmountPoint) {
+    public static Point createUsagePoint(
+            Consumer consumer,
+            Reservation reservation,
+            Integer usageAmountPoint)
+    {
         return createPaymentPoint(consumer, reservation, usageAmountPoint, false);
     }
 }

--- a/common/src/main/java/kernel/maidlab/common/entity/point/Point.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/point/Point.java
@@ -7,7 +7,6 @@ import kernel.maidlab.common.entity.event.Event;
 import kernel.maidlab.common.entity.reservation.Reservation;
 import kernel.maidlab.common.enums.PointType;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -48,33 +47,36 @@ public class Point extends TimeBase {
         return Math.max(earnedPoint, 0);
     }
 
-    public static Point createEarnPointOnPayment(Consumer consumer, Reservation  reservation, BigDecimal totalPrice){
-
-        int payAmount = totalPrice.intValue();
-        Integer earnedPoint = calculateEarnedPoint(payAmount);
-
-        return new Point(
-                consumer,
-                null,  // 이벤트 없음
-                reservation,
-                earnedPoint,
-                PointType.PAYMENT,
-                "결제 적립 포인트"
-        );
-    }
-
-    @Builder
-    public static Point createUsagePoint(Consumer consumer, Reservation reservation, Integer usageAmountPoint){
-
+    public static Point createPaymentPoint(Consumer consumer, Reservation reservation, Integer amount, boolean isEarned) {
+        Integer pointAmount;
+        String description;
+        
+        if (isEarned) {
+            pointAmount = amount;
+            description = "결제 적립 포인트";
+        } else {
+            pointAmount = -Math.abs(amount);
+            description = "결제 사용 포인트";
+        }
+        
         return new Point(
                 consumer,
                 null,
                 reservation,
-                (-Math.abs(usageAmountPoint)),
+                pointAmount,
                 PointType.PAYMENT,
-                "결제 사용 포인트"
-
+                description
         );
+    }
+
+    public static Point createEarnPointOnPayment(Consumer consumer, Reservation reservation, BigDecimal totalPrice) {
+        int payAmount = totalPrice.intValue();
+        Integer earnedPoint = calculateEarnedPoint(payAmount);
+        return createPaymentPoint(consumer, reservation, earnedPoint, true);
+    }
+    
+    public static Point createUsagePoint(Consumer consumer, Reservation reservation, Integer usageAmountPoint) {
+        return createPaymentPoint(consumer, reservation, usageAmountPoint, false);
     }
 }
 

--- a/common/src/main/java/kernel/maidlab/common/entity/point/Point.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/point/Point.java
@@ -6,6 +6,7 @@ import kernel.maidlab.common.entity.consumer.Consumer;
 import kernel.maidlab.common.entity.event.Event;
 import kernel.maidlab.common.entity.reservation.Reservation;
 import kernel.maidlab.common.enums.PointType;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,9 +15,9 @@ import java.math.BigDecimal;
 
 @Entity
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "point")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Point extends TimeBase {
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -47,31 +48,39 @@ public class Point extends TimeBase {
         return Math.max(earnedPoint, 0);
     }
 
-    public static Point createPaymentPoint(
-            Consumer consumer,
-            Reservation reservation,
-            Integer amount,
-            boolean isEarned)
-    {
-        Integer pointAmount;
-        String description;
+    public enum PointAction {
+        EARN("결제 적립 포인트", true),
+        USE("결제 사용 포인트", false),
+        CHARGE("포인트 충전", true);
         
-        if (isEarned) {
-            pointAmount = amount;
-            description = "결제 적립 포인트";
-        } else {
-            pointAmount = -Math.abs(amount);
-            description = "결제 사용 포인트";
+        private final String description;
+        private final boolean isPositive;
+        
+        PointAction(String description, boolean isPositive) {
+            this.description = description;
+            this.isPositive = isPositive;
         }
         
+        public String getDescription() { return description; }
+        public boolean isPositive() { return isPositive; }
+    }
+
+    private static Point createPoint(
+            Consumer consumer,
+            Event event,
+            Reservation reservation,
+            Integer amount,
+            PointType pointType,
+            PointAction action)
+    {
+        Integer finalAmount = action.isPositive() ? amount : -Math.abs(amount);
         return new Point(
                 consumer,
-                null,
+                event,
                 reservation,
-                pointAmount,
-                PointType.PAYMENT,
-                description
-        );
+                finalAmount,
+                pointType,
+                action.getDescription());
     }
 
     public static Point createEarnPointOnPayment(
@@ -81,15 +90,41 @@ public class Point extends TimeBase {
     {
         int payAmount = totalPrice.intValue();
         Integer earnedPoint = calculateEarnedPoint(payAmount);
-        return createPaymentPoint(consumer, reservation, earnedPoint, true);
+
+        return createPoint(
+                consumer,
+                null,
+                reservation,
+                earnedPoint,
+                PointType.PAYMENT,
+                PointAction.EARN);
     }
-    
+
     public static Point createUsagePoint(
             Consumer consumer,
             Reservation reservation,
             Integer usageAmountPoint)
     {
-        return createPaymentPoint(consumer, reservation, usageAmountPoint, false);
+        return createPoint(
+                consumer,
+                null,
+                reservation,
+                usageAmountPoint,
+                PointType.PAYMENT,
+                PointAction.USE);
+    }
+
+    public static Point createChargePoint(
+            Consumer consumer,
+            Integer chargeAmount)
+    {
+        return createPoint(
+                consumer,
+                null,
+                null,
+                chargeAmount,
+                PointType.CHARGE,
+                PointAction.CHARGE);
     }
 }
 

--- a/common/src/main/java/kernel/maidlab/common/entity/reservation/Reservation.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/reservation/Reservation.java
@@ -71,8 +71,9 @@ public class Reservation extends TimeBase {
 	@Column(name = "checkout_time")
 	private LocalDateTime checkoutTime;
 
-	public void pay(){
+	public void pay(Integer pointsToUse){
 		this.status = Status.PAID;
+		this.totalPrice = this.totalPrice.subtract(BigDecimal.valueOf(pointsToUse));
 	}
 
 	public void checkin(LocalDateTime checkinTime) {

--- a/common/src/main/java/kernel/maidlab/common/entity/reservation/Reservation.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/reservation/Reservation.java
@@ -71,9 +71,14 @@ public class Reservation extends TimeBase {
 	@Column(name = "checkout_time")
 	private LocalDateTime checkoutTime;
 
-	public void pay(Integer pointsToUse){
+	public void pay(){
 		this.status = Status.PAID;
-		this.totalPrice = this.totalPrice.subtract(BigDecimal.valueOf(pointsToUse));
+	}
+
+	public void usePoints(Integer pointToUse){
+		if (pointToUse > 0){
+			this.totalPrice = this.totalPrice.subtract(BigDecimal.valueOf(pointToUse));
+		}
 	}
 
 	public void checkin(LocalDateTime checkinTime) {

--- a/common/src/main/java/kernel/maidlab/common/enums/PointType.java
+++ b/common/src/main/java/kernel/maidlab/common/enums/PointType.java
@@ -6,9 +6,10 @@ import lombok.Getter;
 public enum PointType {
 
     PAYMENT("결제"),
-    EVENT("이벤트");
+    EVENT("이벤트"),
+    CHARGE("충전");
 
-    private final String name;
+    private final String type;
 
-    PointType(String name) { this.name= name;}
+    PointType(String type) { this.type= type;}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #225 

## 📝작업 내용

> 
- 결제시 포인트를 사용하여 계산할 수 있도록 구현 (reservation payment API 내에 구현)
- 포인트 충전 api 구현


### 스크린샷 (선택)




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
