### PR TITLE
refactor: Reservation에 finalPaymentPrice 컬럼 추가 (결제시 사용, 예약 상세 조회때 사용)

### DIFF
--- a/api/src/main/java/kernel/maidlab/api/reservation/controller/ReservationController.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/controller/ReservationController.java
@@ -1,33 +1,21 @@
 package kernel.maidlab.api.reservation.controller;
 
-import java.time.LocalDate;
-import java.util.List;
-
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
 import jakarta.servlet.http.HttpServletRequest;
-import kernel.maidlab.common.dto.reservation.request.PaymentRequestDto;
-import kernel.maidlab.common.dto.reservation.request.CheckInOutRequestDto;
-import kernel.maidlab.common.dto.reservation.request.ReservationIsApprovedRequestDto;
-import kernel.maidlab.common.dto.reservation.request.ReservationRequestDto;
-import kernel.maidlab.common.dto.reservation.request.ReviewRegisterRequestDto;
+import kernel.maidlab.api.reservation.service.ReservationService;
+import kernel.maidlab.common.dto.ResponseDto;
+import kernel.maidlab.common.dto.reservation.request.*;
 import kernel.maidlab.common.dto.reservation.response.ReservationDetailResponseDto;
 import kernel.maidlab.common.dto.reservation.response.ReservationResponseDto;
 import kernel.maidlab.common.dto.reservation.response.WeeklySettlementResponseDto;
-import kernel.maidlab.api.reservation.service.ReservationService;
-import kernel.maidlab.common.dto.ResponseDto;
 import kernel.maidlab.common.enums.ResponseType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Slf4j
 @RestController

--- a/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustomImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/repository/ReservationRepositoryCustomImpl.java
@@ -108,6 +108,7 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 				reservation.pet,
 				reservation.specialRequest,
 				reservation.totalPrice,
+				reservation.finalPaymentPrice,
 				region.regionName
 			)
 			.from(reservation)
@@ -150,6 +151,7 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 			.pet(first.get(reservation.pet))
 			.specialRequest(first.get(reservation.specialRequest))
 			.totalPrice(first.get(reservation.totalPrice))
+			.finalPaymentPrice(first.get(reservation.finalPaymentPrice))
 			.build();
 	}
 

--- a/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
@@ -28,6 +28,7 @@ import kernel.maidlab.common.enums.ResponseType;
 import kernel.maidlab.common.enums.ServiceOptionType;
 import kernel.maidlab.common.enums.Status;
 import kernel.maidlab.common.enums.UserType;
+import kernel.maidlab.common.exception.custom.PointException;
 import kernel.maidlab.common.exception.custom.ReservationException;
 import kernel.maidlab.common.util.RoomSizeRuleUtil;
 import lombok.RequiredArgsConstructor;
@@ -282,6 +283,13 @@ public class ReservationServiceImpl implements ReservationService {
 
 		// 결제시 포인트 사용
 		if (dto.isPointUsed()){
+
+			// 사용 가능한 포인트 검증
+			Long useAblePoint = pointRepository.getTotalPointsByConsumerId(consumer.getId());
+			if (useAblePoint < dto.getPointToUse()){
+				throw new PointException(ResponseType.INSUFFICIENT_POINT);
+			}
+
 			reservation.usePoints(dto.getPointToUse());
 
 			// 포인트 차감

--- a/common/src/main/java/kernel/maidlab/common/dto/reservation/response/ReservationDetailResponseDto.java
+++ b/common/src/main/java/kernel/maidlab/common/dto/reservation/response/ReservationDetailResponseDto.java
@@ -43,4 +43,5 @@ public class ReservationDetailResponseDto {
 	private String specialRequest;
 
 	private BigDecimal totalPrice;
+	private BigDecimal finalPaymentPrice;
 }

--- a/common/src/main/java/kernel/maidlab/common/entity/reservation/Reservation.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/reservation/Reservation.java
@@ -71,13 +71,16 @@ public class Reservation extends TimeBase {
 	@Column(name = "checkout_time")
 	private LocalDateTime checkoutTime;
 
+	@Column(name = "final_payment_price")
+	private BigDecimal finalPaymentPrice;
+
 	public void pay(){
 		this.status = Status.PAID;
 	}
 
 	public void usePoints(Integer pointToUse){
 		if (pointToUse > 0){
-			this.totalPrice = this.totalPrice.subtract(BigDecimal.valueOf(pointToUse));
+			this.finalPaymentPrice = this.totalPrice.subtract(BigDecimal.valueOf(pointToUse));
 		}
 	}
 

--- a/common/src/main/java/kernel/maidlab/common/entity/reservation/Reservation.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/reservation/Reservation.java
@@ -72,15 +72,20 @@ public class Reservation extends TimeBase {
 	private LocalDateTime checkoutTime;
 
 	@Column(name = "final_payment_price")
-	private BigDecimal finalPaymentPrice;
+	private BigDecimal finalPaymentPrice = BigDecimal.ZERO;
 
 	public void pay(){
 		this.status = Status.PAID;
+		if (this.finalPaymentPrice.compareTo(BigDecimal.ZERO) == 0){
+			this.finalPaymentPrice = this.totalPrice;
+		}
 	}
 
 	public void usePoints(Integer pointToUse){
 		if (pointToUse > 0){
-			this.finalPaymentPrice = this.totalPrice.subtract(BigDecimal.valueOf(pointToUse));
+			BigDecimal pointValue = BigDecimal.valueOf(pointToUse);
+			BigDecimal newPrice = this.totalPrice.subtract(pointValue);
+			this.finalPaymentPrice = newPrice.compareTo(BigDecimal.ZERO) < 0 ? BigDecimal.ZERO : newPrice;
 		}
 	}
 

--- a/common/src/main/java/kernel/maidlab/common/enums/ResponseType.java
+++ b/common/src/main/java/kernel/maidlab/common/enums/ResponseType.java
@@ -37,7 +37,10 @@ public enum ResponseType {
 	AVAILABLE_MANAGER_DOES_NOT_EXIST("NM", "Available manager does not exist.", HttpStatus.NOT_FOUND),
 
 	// 500
-	DATABASE_ERROR("DBE", "Database error.", HttpStatus.INTERNAL_SERVER_ERROR);
+	DATABASE_ERROR("DBE", "Database error.", HttpStatus.INTERNAL_SERVER_ERROR),
+
+	// 포인트 관련 에러
+	INSUFFICIENT_POINT("VF", "사용 가능한 포인트가 부족합니다.", HttpStatus.BAD_REQUEST);
 
 	private final String code;
 	private final String message;

--- a/common/src/main/java/kernel/maidlab/common/exception/custom/PointException.java
+++ b/common/src/main/java/kernel/maidlab/common/exception/custom/PointException.java
@@ -1,0 +1,11 @@
+package kernel.maidlab.common.exception.custom;
+
+import kernel.maidlab.common.enums.ResponseType;
+import kernel.maidlab.common.exception.BaseException;
+
+public class PointException extends BaseException {
+
+    public PointException(ResponseType responseType) {
+        super(responseType);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #228 

## 📝작업 내용

> 
- point 결제시 (전체 금액 - point)를 저장하는 멤버 변수 추가 - finalPaymentPrice
- 예약 상세 조회시  finalPaymentPrice도 같이 조회 할 수 있도록 수정


### 스크린샷 (선택)




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
