### PR TITLE
알림 관련 오류 수정

### DIFF
--- a/api/src/main/java/kernel/maidlab/api/manager/service/ManagerService.java
+++ b/api/src/main/java/kernel/maidlab/api/manager/service/ManagerService.java
@@ -18,6 +18,7 @@ import kernel.maidlab.common.dto.manager.ManagerListResponseDto;
 import kernel.maidlab.common.dto.manager.ManagerResponseDto;
 import kernel.maidlab.common.dto.matching.response.AvailableManagerResponseDto;
 import kernel.maidlab.common.entity.consumer.Consumer;
+import kernel.maidlab.common.entity.manager.Manager;
 import kernel.maidlab.common.enums.Status;
 
 public interface ManagerService {
@@ -35,4 +36,6 @@ public interface ManagerService {
 	List<AvailableManagerResponseDto> findAvailableManagers(String gu, LocalDateTime StartTime, LocalDateTime EndTime);
 
 	List<AvailableManagerResponseDto> previousManagers(Consumer consumer);
+
+	Manager findById(Long managerId);
 }

--- a/api/src/main/java/kernel/maidlab/api/manager/service/ManagerServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/manager/service/ManagerServiceImpl.java
@@ -308,4 +308,9 @@ public class ManagerServiceImpl implements ManagerService {
 		return managerRepository.previousManagers(consumer);
 	}
 
+	@Override
+	public Manager findById(Long managerId) {
+		return managerRepository.findById(managerId).orElse(null);
+	}
+
 }

--- a/api/src/main/java/kernel/maidlab/api/matching/service/MatchingServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/matching/service/MatchingServiceImpl.java
@@ -13,6 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.transaction.Transactional;
 import kernel.maidlab.api.auth.jwt.JwtFilter;
 import kernel.maidlab.api.consumer.service.ConsumerService;
+import kernel.maidlab.api.manager.repository.ManagerRepository;
 import kernel.maidlab.api.manager.service.ManagerService;
 import kernel.maidlab.api.notification.service.NotificationService;
 import kernel.maidlab.api.reservation.repository.ReservationRepository;
@@ -42,6 +43,7 @@ public class MatchingServiceImpl implements MatchingService {
 	private final ReservationRepository reservationRepository;
 	private final ConsumerService consumerService;
 	private final NotificationService notificationService;
+	private final ManagerRepository managerRepository;
 
 	@Override
 	public List<AvailableManagerResponseDto> findAvailableManagers(MatchingRequestDto dto) {
@@ -199,17 +201,17 @@ public class MatchingServiceImpl implements MatchingService {
 				.orElseThrow(
 					() -> new IllegalArgumentException("예약 정보를 찾을 수 없습니다. ID: " + matching.getReservationId()));
 
-			// 소비자 정보 조회
+			// 소비자, 매니저 정보 조회
 			Consumer consumer = consumerService.findById(reservation.getConsumerId());
-
+			Manager manager = managerService.findById(reservation.getManagerId());
 			// 서비스 타입 정보
 			String serviceType = reservation.getServiceDetailType().getServiceDetailType();
 
 			// 새로운 알림 시스템 사용
 			NotificationDto notification = notificationService.createMatchingStatusNotification(
 				consumer.getId(),
-				matching.getManagerId(),
-				consumer.getName(),
+				matching.getId(),
+				manager.getName(),
 				status
 			);
 

--- a/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/reservation/service/ReservationServiceImpl.java
@@ -32,6 +32,7 @@ import kernel.maidlab.common.exception.custom.ReservationException;
 import kernel.maidlab.common.util.RoomSizeRuleUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -79,7 +80,8 @@ public class ReservationServiceImpl implements ReservationService {
 			// 매니저 선호도 테이블 관리
 			if (dto.getLikes() != null) {
 				managerPreferenceRepository.save(new ManagerPreference(consumer, manager, dto.getLikes()));
-				log.info("매니저 선호도 등록 - Consumer ID: {}, Manager ID: {}, 선호도: {}", consumer.getId(), manager.getId(), dto.getLikes());
+				log.info("매니저 선호도 등록 - Consumer ID: {}, Manager ID: {}, 선호도: {}", consumer.getId(), manager.getId(),
+					dto.getLikes());
 			}
 
 			// 매니저 평균 평점(average_rate) 관리
@@ -88,11 +90,13 @@ public class ReservationServiceImpl implements ReservationService {
 			if (managerTotalReviewedCnt == 0) {
 				manager.updateAverageRate(dto.getRating());
 			} else {
-				Float newAverageRate = (managerTotalReviewedCnt * averageRate + dto.getRating()) / (managerTotalReviewedCnt + 1);
+				Float newAverageRate =
+					(managerTotalReviewedCnt * averageRate + dto.getRating()) / (managerTotalReviewedCnt + 1);
 				manager.updateAverageRate(newAverageRate);
 			}
 			managerRepository.save(manager);
-			log.info("매니저 평균 평점 업데이트 - Manager ID: {}, 이전 평점: {}, 새 평점: {}", manager.getId(), averageRate, manager.getAverageRate());
+			log.info("매니저 평균 평점 업데이트 - Manager ID: {}, 이전 평점: {}, 새 평점: {}", manager.getId(), averageRate,
+				manager.getAverageRate());
 
 		} else if (userType == UserType.MANAGER) {
 			Consumer consumer = consumerRepository.findById(reservation.getConsumerId())
@@ -104,11 +108,13 @@ public class ReservationServiceImpl implements ReservationService {
 			if (consumerTotalReviewedCnt == 0) {
 				consumer.updateAverageRate(dto.getRating());
 			} else {
-				Float newAverageRate = (consumerTotalReviewedCnt * averageRate + dto.getRating()) / (consumerTotalReviewedCnt + 1);
+				Float newAverageRate =
+					(consumerTotalReviewedCnt * averageRate + dto.getRating()) / (consumerTotalReviewedCnt + 1);
 				consumer.updateAverageRate(newAverageRate);
 			}
 			consumerRepository.save(consumer);
-			log.info("Consumer 평균 평점 업데이트 - Consumer ID: {}, 이전 평점: {}, 새 평점: {}", consumer.getId(), averageRate, consumer.getAverageRate());
+			log.info("Consumer 평균 평점 업데이트 - Consumer ID: {}, 이전 평점: {}, 새 평점: {}", consumer.getId(), averageRate,
+				consumer.getAverageRate());
 		} else {
 			throw new ReservationException(ResponseType.INVALID_USER_TYPE);
 		}
@@ -126,6 +132,7 @@ public class ReservationServiceImpl implements ReservationService {
 		}
 		log.info("리뷰 등록 완료 - 리뷰 ID: {}, 예약 ID: {}", savedReview.getId(), reservation.getId());
 	}
+
 	// 이전 예약 전체 조회 api
 	@Override
 	public List<ReservationResponseDto> allReservations(HttpServletRequest request) {
@@ -142,51 +149,54 @@ public class ReservationServiceImpl implements ReservationService {
 	}
 
 	// 고객 맞춤 예약 내역 페이징 및 상태별 필터링
-    @Override
-    public Page<ReservationResponseDto> getConsumerReservationsWithPaging(String status, int page, int size, String sortBy, String sortOrder, HttpServletRequest request) {
-        Consumer consumer = authUtil.getConsumer(request);
-        Long consumerId = consumer.getId();
+	@Override
+	public Page<ReservationResponseDto> getConsumerReservationsWithPaging(String status, int page, int size,
+		String sortBy, String sortOrder, HttpServletRequest request) {
+		Consumer consumer = authUtil.getConsumer(request);
+		Long consumerId = consumer.getId();
 
-        if (size > 50) {
-            size = 50;
-        }
+		if (size > 50) {
+			size = 50;
+		}
 
-        Set<String> allowedSortFields = new HashSet<>(Arrays.asList("createdAt", "reservationDate", "totalPrice", "completedAt", "startTime"));
-        if (!allowedSortFields.contains(sortBy)) {
-            sortBy = "createdAt";
-        }
+		Set<String> allowedSortFields = new HashSet<>(
+			Arrays.asList("createdAt", "reservationDate", "totalPrice", "completedAt", "startTime"));
+		if (!allowedSortFields.contains(sortBy)) {
+			sortBy = "createdAt";
+		}
 
-        Status statusEnum = null;
-        if (status != null && !status.trim().isEmpty()) {
-            try {
-                statusEnum = Status.valueOf(status.toUpperCase());
-            } catch (IllegalArgumentException e) {
-                throw new ReservationException(ResponseType.VALIDATION_FAILED);
-            }
-        }
+		Status statusEnum = null;
+		if (status != null && !status.trim().isEmpty()) {
+			try {
+				statusEnum = Status.valueOf(status.toUpperCase());
+			} catch (IllegalArgumentException e) {
+				throw new ReservationException(ResponseType.VALIDATION_FAILED);
+			}
+		}
 
-        Sort.Direction direction = "ASC".equalsIgnoreCase(sortOrder) ? Sort.Direction.ASC : Sort.Direction.DESC;
-        Sort sort = Sort.by(direction, sortBy);
-        Pageable pageable = PageRequest.of(page, size, sort);
+		Sort.Direction direction = "ASC".equalsIgnoreCase(sortOrder) ? Sort.Direction.ASC : Sort.Direction.DESC;
+		Sort sort = Sort.by(direction, sortBy);
+		Pageable pageable = PageRequest.of(page, size, sort);
 
-        return reservationRepository.findConsumerReservationsWithPaging(consumerId, statusEnum, pageable);
-    }
+		return reservationRepository.findConsumerReservationsWithPaging(consumerId, statusEnum, pageable);
+	}
 
-    @Override
-    public Page<ReservationResponseDto> getManagerReservationsWithPaging(String status, int page, int size, String sortOrder, HttpServletRequest request) {
-        Manager manager = authUtil.getManager(request);
-        Long managerId = manager.getId();
+	@Override
+	public Page<ReservationResponseDto> getManagerReservationsWithPaging(String status, int page, int size,
+		String sortOrder, HttpServletRequest request) {
+		Manager manager = authUtil.getManager(request);
+		Long managerId = manager.getId();
 
-        if (size > 50) {
-            size = 50;
-        }
+		if (size > 50) {
+			size = 50;
+		}
 
-        Sort.Direction direction = "ASC".equalsIgnoreCase(sortOrder) ? Sort.Direction.ASC : Sort.Direction.DESC;
-        Sort sort = Sort.by(direction, "reservationDate");
-        Pageable pageable = PageRequest.of(page, size, sort);
+		Sort.Direction direction = "ASC".equalsIgnoreCase(sortOrder) ? Sort.Direction.ASC : Sort.Direction.DESC;
+		Sort sort = Sort.by(direction, "reservationDate");
+		Pageable pageable = PageRequest.of(page, size, sort);
 
-        return reservationRepository.getManagerReservationsWithPaging(managerId, status, pageable);
-    }
+		return reservationRepository.getManagerReservationsWithPaging(managerId, status, pageable);
+	}
 
 	@Override
 	public ReservationDetailResponseDto getReservationDetail(Long reservationId, HttpServletRequest request) {
@@ -206,13 +216,12 @@ public class ReservationServiceImpl implements ReservationService {
 	@Override
 	public Long createReservation(ReservationRequestDto dto, HttpServletRequest request) {
 		// 매칭된 매니저 존재 확인
-		if (dto.getManagerUuid().isEmpty() || dto.getManagerUuid().isBlank()){
+		if (dto.getManagerUuid().isEmpty() || dto.getManagerUuid().isBlank()) {
 			throw new ReservationException(ResponseType.AVAILABLE_MANAGER_DOES_NOT_EXIST);
 		}
 
 		Consumer consumer = (Consumer)request.getAttribute(JwtFilter.CURRENT_USER_KEY);
 		Long consumerId = consumer.getId();
-
 
 		// 결제 검증 로직(애플리케이션 상용 전 true 고정)
 		boolean payValid = true;
@@ -234,7 +243,8 @@ public class ReservationServiceImpl implements ReservationService {
 
 		Reservation reservation = Reservation.of(dto, consumerId, managerId, detailType);
 		Reservation matchingReservation = reservationRepository.save(reservation);
-		log.info("예약 생성 완료 - 예약 ID: {}, Consumer ID: {}, Manager ID: {}", matchingReservation.getId(), consumerId, managerId);
+		log.info("예약 생성 완료 - 예약 ID: {}, Consumer ID: {}, Manager ID: {}", matchingReservation.getId(), consumerId,
+			managerId);
 
 		// 예약 완료 시 manager 매칭
 		MatchingResponseDto match = MatchingResponseDto.builder()
@@ -268,17 +278,18 @@ public class ReservationServiceImpl implements ReservationService {
 		}
 		reservationRepository.save(reservation);
 	}
+
 	@Transactional
 	@Override
-	public void pay(PaymentRequestDto dto, HttpServletRequest request){
+	public void pay(PaymentRequestDto dto, HttpServletRequest request) {
 
-		Consumer consumer = (Consumer) request.getAttribute(JwtFilter.CURRENT_USER_KEY);
+		Consumer consumer = (Consumer)request.getAttribute(JwtFilter.CURRENT_USER_KEY);
 
 		Reservation reservation = reservationRepository.findById(dto.getReservationId())
-				.orElseThrow(() -> new ReservationException(ResponseType.DATABASE_ERROR));
+			.orElseThrow(() -> new ReservationException(ResponseType.DATABASE_ERROR));
 
 		// 결제시 포인트 사용
-		if (dto.isPointUsed()){
+		if (dto.isPointUsed()) {
 			reservation.usePoints(dto.getPointToUse());
 
 			// 포인트 차감
@@ -298,7 +309,8 @@ public class ReservationServiceImpl implements ReservationService {
 	}
 
 	private void sendReservationPaidNotification(Long managerId, Long reservationId, String consumerName) {
-		NotificationDto notification = notificationService.createReservationPaidNotification(managerId, reservationId, consumerName);
+		NotificationDto notification = notificationService.createReservationPaidNotification(managerId, reservationId,
+			consumerName);
 		notificationService.sendNotification(notification);
 	}
 
@@ -308,8 +320,7 @@ public class ReservationServiceImpl implements ReservationService {
 		Reservation reservation = reservationRepository.findById(reservationId)
 			.orElseThrow(() -> new ReservationException(ResponseType.DATABASE_ERROR));
 
-		Manager manager = (Manager) request.getAttribute(JwtFilter.CURRENT_USER_KEY);
-
+		Manager manager = (Manager)request.getAttribute(JwtFilter.CURRENT_USER_KEY);
 
 		if (!reservation.getManagerId().equals(manager.getId())) {
 			throw new ReservationException(ResponseType.DO_NOT_HAVE_PERMISSION);
@@ -326,7 +337,8 @@ public class ReservationServiceImpl implements ReservationService {
 	}
 
 	private void sendReservationCheckInNotification(Long consumerId, Long reservationId, String name) {
-		NotificationDto notification = notificationService.createReservationCheckInNotification(consumerId, reservationId, name);
+		NotificationDto notification = notificationService.createReservationCheckInNotification(consumerId,
+			reservationId, name);
 		notificationService.sendNotification(notification);
 	}
 
@@ -336,7 +348,7 @@ public class ReservationServiceImpl implements ReservationService {
 		Reservation reservation = reservationRepository.findById(reservationId)
 			.orElseThrow(() -> new ReservationException(ResponseType.DATABASE_ERROR));
 
-		Manager manager = (Manager) request.getAttribute(JwtFilter.CURRENT_USER_KEY);
+		Manager manager = (Manager)request.getAttribute(JwtFilter.CURRENT_USER_KEY);
 		Long managerId = authUtil.getManager(request).getId();
 
 		if (!reservation.getManagerId().equals(managerId)) {
@@ -358,14 +370,15 @@ public class ReservationServiceImpl implements ReservationService {
 	}
 
 	private void sendReservationCheckOutNotification(Long consumerId, Long reservationId, String managerName) {
-		NotificationDto notification = notificationService.createReservationCheckOutNotification(consumerId, reservationId, managerName);
+		NotificationDto notification = notificationService.createReservationCheckOutNotification(consumerId,
+			reservationId, managerName);
 		notificationService.sendNotification(notification);
 	}
 
 	@Transactional
 	@Override
 	public void cancel(Long reservationId, HttpServletRequest request) {
-		Consumer consumer = (Consumer) request.getAttribute(JwtFilter.CURRENT_USER_KEY);
+		Consumer consumer = (Consumer)request.getAttribute(JwtFilter.CURRENT_USER_KEY);
 		Reservation reservation = reservationRepository.findById(reservationId)
 			.orElseThrow(() -> new ReservationException(ResponseType.DATABASE_ERROR));
 		if (!reservation.getConsumerId().equals(consumer.getId())) {
@@ -375,9 +388,10 @@ public class ReservationServiceImpl implements ReservationService {
 		if (reservation.getStatus() != Status.PENDING && reservation.getStatus() != Status.MATCHED) {
 			throw new ReservationException(ResponseType.ALREADY_WORKING_OR_COMPLETED);
 		}
+
 		reservation.cancel(LocalDateTime.now());
 		reservationRepository.save(reservation);
-		if (matchingRepository.existsById(matchingRepository.findByReservationId(reservationId).getId())) {
+		if (matchingRepository.existsByReservationId(reservationId)) {
 			matchingRepository.deleteById(matchingRepository.findByReservationId(reservationId).getId());
 		}
 
@@ -386,7 +400,8 @@ public class ReservationServiceImpl implements ReservationService {
 	}
 
 	private void sendReservationCanceledNotification(Long managerId, Long reservationId, String consumerName) {
-		NotificationDto notification =  notificationService.createReservationCancelNotification(managerId, reservationId, consumerName);
+		NotificationDto notification = notificationService.createReservationCancelNotification(managerId, reservationId,
+			consumerName);
 		notificationService.sendNotification(notification);
 	}
 
@@ -436,7 +451,8 @@ public class ReservationServiceImpl implements ReservationService {
 
 			totalAmount = totalAmount.add(settlement.getAmount());
 
-			responseList.add(new SettlementResponseDto(settlement.getId(), settlement.getReservationId(), settlement.getServiceType(),
+			responseList.add(new SettlementResponseDto(settlement.getId(), settlement.getReservationId(),
+				settlement.getServiceType(),
 				detailType.getServiceDetailType(), settlement.getStatus(), settlement.getPlatformFee(),
 				settlement.getAmount()));
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#220 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. relatedid에 matching엔티티의 id값이 들어가고 있지 않았고, 소비자에게 전달되어지는 메세지에서 매니저 이름이 아닌 소비자의 이름을 전송함
2. 예약 취소시 해당 예약에 대한 매칭이 존재하는지 확인하는 로직에서 이미 삭제된 매칭의 id를 이용하여 매칭을 조회하느라 에러가 발생하는 것을 확인 -> 매칭 id가 아닌 예약 id 값을 이용해 조회함으로 해결

### 스크린샷 (선택)




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
