### PR TITLE
consumer response 정적 팩토리 메서드명 from으로 통일,  ConsumerService - CosumerServiceImpl  분리

### DIFF
--- a/api/src/main/java/kernel/maidlab/api/consumer/service/ConsumerService.java
+++ b/api/src/main/java/kernel/maidlab/api/consumer/service/ConsumerService.java
@@ -37,7 +37,7 @@ public class ConsumerService {
 	public ConsumerMyPageDto getConsumerMyPage(HttpServletRequest req){
 
 		Consumer findedConsumer = getConsumer(req);
-		return ConsumerMyPageDto.getInstance(findedConsumer);
+		return ConsumerMyPageDto.from(findedConsumer);
 	}
 
 
@@ -45,7 +45,7 @@ public class ConsumerService {
 	public ConsumerProfileResponseDto getConsumerProfile(HttpServletRequest req) {
 
 		Consumer consumer = getConsumer(req);
-		return ConsumerProfileResponseDto.getInstance(consumer);
+		return ConsumerProfileResponseDto.from(consumer);
 	}
 
 	public void createConsumerProfile(
@@ -81,7 +81,7 @@ public class ConsumerService {
 		List<Manager> likedManagerList = managerPreferenceRepositoryCustom
 				.findManagersByPreference(consumer.getId(), true);
 
-		return LikedManagerResponseDto.getLikedManagerResponseDtoList(likedManagerList);
+		return LikedManagerResponseDto.from(likedManagerList);
 	}
 
 	// 블랙 리스트 매니저 조회
@@ -93,7 +93,7 @@ public class ConsumerService {
 		List<Manager> BlacklistedManagerList = managerPreferenceRepositoryCustom
 				.findManagersByPreference(consumer.getId(), false);
 
-		return BlackListedManagerResponseDto.getManagerResponseDtoList(BlacklistedManagerList);
+		return BlackListedManagerResponseDto.from(BlacklistedManagerList);
 	}
 
 	// 찜/블랙리스트 매니저 등록

--- a/api/src/main/java/kernel/maidlab/api/consumer/service/ConsumerService.java
+++ b/api/src/main/java/kernel/maidlab/api/consumer/service/ConsumerService.java
@@ -1,11 +1,6 @@
 package kernel.maidlab.api.consumer.service;
 
 import jakarta.servlet.http.HttpServletRequest;
-import kernel.maidlab.api.auth.jwt.JwtFilter;
-import kernel.maidlab.api.consumer.repository.ConsumerRepository;
-import kernel.maidlab.api.consumer.repository.ManagerPreferenceRepository;
-import kernel.maidlab.api.consumer.repository.ManagerPreferenceRepositoryCustom;
-import kernel.maidlab.api.manager.repository.ManagerRepository;
 import kernel.maidlab.common.dto.consumer.ConsumerMyPageDto;
 import kernel.maidlab.common.dto.consumer.request.ConsumerProfileRequestDto;
 import kernel.maidlab.common.dto.consumer.request.ConsumerProfileUpdateRequestDto;
@@ -13,127 +8,28 @@ import kernel.maidlab.common.dto.consumer.response.BlackListedManagerResponseDto
 import kernel.maidlab.common.dto.consumer.response.ConsumerProfileResponseDto;
 import kernel.maidlab.common.dto.consumer.response.LikedManagerResponseDto;
 import kernel.maidlab.common.entity.consumer.Consumer;
-import kernel.maidlab.common.entity.consumer.ManagerPreference;
-import kernel.maidlab.common.entity.manager.Manager;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-@Slf4j
-@Service
-@Transactional
-@RequiredArgsConstructor
-public class ConsumerService {
+public interface ConsumerService {
 
-	private final ConsumerRepository consumerRepository;
-	private final ManagerPreferenceRepository managerPreferenceRepository;
-	private final ManagerPreferenceRepositoryCustom managerPreferenceRepositoryCustom;
-	private final ManagerRepository managerRepository;
+	ConsumerMyPageDto getConsumerMyPage(HttpServletRequest req);
 
-	@Transactional(readOnly = true)
-	public ConsumerMyPageDto getConsumerMyPage(HttpServletRequest req){
+	ConsumerProfileResponseDto getConsumerProfile(HttpServletRequest req);
 
-		Consumer findedConsumer = getConsumer(req);
-		return ConsumerMyPageDto.from(findedConsumer);
-	}
+	void createConsumerProfile(ConsumerProfileRequestDto consumerProfileRequestDto, HttpServletRequest req);
 
+	void updateConsumerProfile(ConsumerProfileUpdateRequestDto consumerProfileUpdateRequestDto, HttpServletRequest req);
 
-	@Transactional(readOnly = true)
-	public ConsumerProfileResponseDto getConsumerProfile(HttpServletRequest req) {
+	List<LikedManagerResponseDto> getLikedManagerList(HttpServletRequest req);
 
-		Consumer consumer = getConsumer(req);
-		return ConsumerProfileResponseDto.from(consumer);
-	}
+	List<BlackListedManagerResponseDto> getBlackListedManagerList(HttpServletRequest req);
 
-	public void createConsumerProfile(
-			ConsumerProfileRequestDto consumerProfileRequestDto,
-			HttpServletRequest req)
-	{
-		Consumer consumer = getConsumer(req);
+	void saveLikedOrBlackListedManager(HttpServletRequest req, String managerUuid, boolean preference);
 
-		String profileImage = consumerProfileRequestDto.getProfileImage();
-		String address = consumerProfileRequestDto.getAddress();
-		String detailAddress = consumerProfileRequestDto.getDetailAddress();
+	long deleteLikedAOrBlackListManager(String managerUuid, HttpServletRequest req);
 
-		consumer.createProfile(profileImage, address, detailAddress);
-		consumerRepository.save(consumer);
-	}
+	Consumer getConsumer(HttpServletRequest req);
 
-	public void updateConsumerProfile(
-			ConsumerProfileUpdateRequestDto consumerProfileUpdateRequestDto,
-			HttpServletRequest req){
-
-		Consumer consumer = getConsumer(req);
-		consumer.updateProfile(consumerProfileUpdateRequestDto);
-		consumerRepository.save(consumer);
-	}
-
-
-	// 찜한 매니저 조회
-	@Transactional(readOnly = true)
-	public List<LikedManagerResponseDto> getLikedManagerList(HttpServletRequest req) {
-
-		Consumer consumer = getConsumer(req);
-
-		List<Manager> likedManagerList = managerPreferenceRepositoryCustom
-				.findManagersByPreference(consumer.getId(), true);
-
-		return LikedManagerResponseDto.from(likedManagerList);
-	}
-
-	// 블랙 리스트 매니저 조회
-	@Transactional(readOnly = true)
-	public List<BlackListedManagerResponseDto> getBlackListedManagerList(HttpServletRequest req) {
-
-		Consumer consumer = getConsumer(req);
-
-		List<Manager> BlacklistedManagerList = managerPreferenceRepositoryCustom
-				.findManagersByPreference(consumer.getId(), false);
-
-		return BlackListedManagerResponseDto.from(BlacklistedManagerList);
-	}
-
-	// 찜/블랙리스트 매니저 등록
-	public void saveLikedOrBlackListedManager(
-			HttpServletRequest req,
-			String managerUuid,
-			boolean preference) {
-
-		Consumer consumer = getConsumer(req);
-
-		Manager manager = managerRepository.findByUuid(managerUuid).
-			orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매니저 입니다."));
-
-		ManagerPreference managerPreference = new ManagerPreference(consumer, manager, preference);
-		managerPreferenceRepository.save(managerPreference);
-	}
-
-	public long deleteLikedAOrBlackListManager(
-			String managerUuid,
-			HttpServletRequest req) {
-
-		Consumer consumer = getConsumer(req);
-
-		Manager manager = managerRepository.findByUuid(managerUuid)
-			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매니저입니다."));
-
-		return managerPreferenceRepository.
-				deleteByConsumerIdAndManagerId(
-					consumer.getId(),
-					manager.getId());
-	}
-
-	public Consumer getConsumer(HttpServletRequest req){
-		return (Consumer)req.getAttribute(JwtFilter.CURRENT_USER_KEY);
-	}
-	
-	@Transactional(readOnly = true)
-	public Consumer findById(Long consumerId) {
-		return consumerRepository.findById(consumerId)
-			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 소비자입니다. ID: " + consumerId));
-	}
-
+	Consumer findById(Long consumerId);
 }

--- a/api/src/main/java/kernel/maidlab/api/consumer/service/ConsumerServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/consumer/service/ConsumerServiceImpl.java
@@ -1,0 +1,110 @@
+package kernel.maidlab.api.consumer.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import kernel.maidlab.api.auth.jwt.JwtFilter;
+import kernel.maidlab.api.consumer.repository.ConsumerRepository;
+import kernel.maidlab.api.consumer.repository.ManagerPreferenceRepository;
+import kernel.maidlab.api.consumer.repository.ManagerPreferenceRepositoryCustom;
+import kernel.maidlab.api.manager.repository.ManagerRepository;
+import kernel.maidlab.common.dto.consumer.ConsumerMyPageDto;
+import kernel.maidlab.common.dto.consumer.request.ConsumerProfileRequestDto;
+import kernel.maidlab.common.dto.consumer.request.ConsumerProfileUpdateRequestDto;
+import kernel.maidlab.common.dto.consumer.response.BlackListedManagerResponseDto;
+import kernel.maidlab.common.dto.consumer.response.ConsumerProfileResponseDto;
+import kernel.maidlab.common.dto.consumer.response.LikedManagerResponseDto;
+import kernel.maidlab.common.entity.consumer.Consumer;
+import kernel.maidlab.common.entity.consumer.ManagerPreference;
+import kernel.maidlab.common.entity.manager.Manager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ConsumerServiceImpl implements ConsumerService {
+
+    private final ConsumerRepository consumerRepository;
+    private final ManagerPreferenceRepository managerPreferenceRepository;
+    private final ManagerPreferenceRepositoryCustom managerPreferenceRepositoryCustom;
+    private final ManagerRepository managerRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public ConsumerMyPageDto getConsumerMyPage(HttpServletRequest req) {
+        Consumer findedConsumer = getConsumer(req);
+        return ConsumerMyPageDto.from(findedConsumer);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public ConsumerProfileResponseDto getConsumerProfile(HttpServletRequest req) {
+        Consumer consumer = getConsumer(req);
+        return ConsumerProfileResponseDto.from(consumer);
+    }
+
+    @Override
+    public void createConsumerProfile(ConsumerProfileRequestDto consumerProfileRequestDto, HttpServletRequest req) {
+        Consumer consumer = getConsumer(req);
+        consumer.createProfile(consumerProfileRequestDto);
+        consumerRepository.save(consumer);
+    }
+
+    @Override
+    public void updateConsumerProfile(ConsumerProfileUpdateRequestDto consumerProfileUpdateRequestDto, HttpServletRequest req) {
+        Consumer consumer = getConsumer(req);
+        consumer.updateProfile(consumerProfileUpdateRequestDto);
+        consumerRepository.save(consumer);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<LikedManagerResponseDto> getLikedManagerList(HttpServletRequest req) {
+        Consumer consumer = getConsumer(req);
+        List<Manager> likedManagerList = managerPreferenceRepositoryCustom
+                .findManagersByPreference(consumer.getId(), true);
+        return LikedManagerResponseDto.from(likedManagerList);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<BlackListedManagerResponseDto> getBlackListedManagerList(HttpServletRequest req) {
+        Consumer consumer = getConsumer(req);
+        List<Manager> blacklistedManagerList = managerPreferenceRepositoryCustom
+                .findManagersByPreference(consumer.getId(), false);
+        return BlackListedManagerResponseDto.from(blacklistedManagerList);
+    }
+
+    @Override
+    public void saveLikedOrBlackListedManager(HttpServletRequest req, String managerUuid, boolean preference) {
+        Consumer consumer = getConsumer(req);
+        Manager manager = managerRepository.findByUuid(managerUuid)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매니저 입니다."));
+        ManagerPreference managerPreference = new ManagerPreference(consumer, manager, preference);
+        managerPreferenceRepository.save(managerPreference);
+    }
+
+    @Override
+    public long deleteLikedAOrBlackListManager(String managerUuid, HttpServletRequest req) {
+        Consumer consumer = getConsumer(req);
+        Manager manager = managerRepository.findByUuid(managerUuid)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매니저입니다."));
+        return managerPreferenceRepository.deleteByConsumerIdAndManagerId(consumer.getId(), manager.getId());
+    }
+
+    @Override
+    public Consumer getConsumer(HttpServletRequest req) {
+        return (Consumer) req.getAttribute(JwtFilter.CURRENT_USER_KEY);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Consumer findById(Long consumerId) {
+        return consumerRepository.findById(consumerId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 소비자입니다. ID: " + consumerId));
+    }
+}

--- a/api/src/main/java/kernel/maidlab/api/point/controller/PointController.java
+++ b/api/src/main/java/kernel/maidlab/api/point/controller/PointController.java
@@ -32,8 +32,8 @@ public class PointController {
             HttpServletRequest request,
             @RequestBody PointRecordRequestDto pointRecordRequestDto){
 
-        PageResponseDto<PointRecordResponseDto> pointRecordList = pointService.getPointRecordList(request, pointRecordRequestDto);
-
+        PageResponseDto<PointRecordResponseDto> pointRecordList =
+                pointService.getPointRecordList(request, pointRecordRequestDto);
         return ResponseDto.success(pointRecordList);
     }
 

--- a/common/src/main/java/kernel/maidlab/common/dto/consumer/ConsumerMyPageDto.java
+++ b/common/src/main/java/kernel/maidlab/common/dto/consumer/ConsumerMyPageDto.java
@@ -14,7 +14,7 @@ public class ConsumerMyPageDto {
     private String profileImage;
     private SocialType socialType;
 
-    public static ConsumerMyPageDto getInstance(Consumer consumer){
+    public static ConsumerMyPageDto from(Consumer consumer){
 
         return new ConsumerMyPageDto(
                 consumer.getName(),

--- a/common/src/main/java/kernel/maidlab/common/dto/consumer/response/AdminConsumerProfileResponseDto.java
+++ b/common/src/main/java/kernel/maidlab/common/dto/consumer/response/AdminConsumerProfileResponseDto.java
@@ -1,16 +1,13 @@
 package kernel.maidlab.common.dto.consumer.response;
 
 import kernel.maidlab.common.entity.consumer.Consumer;
-import kernel.maidlab.common.entity.manager.Manager;
 import kernel.maidlab.common.enums.Gender;
-import kernel.maidlab.common.enums.Region;
 import kernel.maidlab.common.enums.SocialType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Getter
 @Builder
@@ -28,7 +25,7 @@ public class AdminConsumerProfileResponseDto {
     private Boolean isDeleted;
     private SocialType socialType;
 
-    public static AdminConsumerProfileResponseDto getInstance(Consumer consumer){
+    public static AdminConsumerProfileResponseDto from(Consumer consumer){
 
         return new AdminConsumerProfileResponseDto(
                 consumer.getProfileImage(),

--- a/common/src/main/java/kernel/maidlab/common/dto/consumer/response/BlackListedManagerResponseDto.java
+++ b/common/src/main/java/kernel/maidlab/common/dto/consumer/response/BlackListedManagerResponseDto.java
@@ -18,7 +18,7 @@ public class BlackListedManagerResponseDto {
     private float  averageRate;
     private String introduceText;
 
-    public static List<BlackListedManagerResponseDto> getManagerResponseDtoList(List<Manager> BlacklistedManagerList){
+    public static List<BlackListedManagerResponseDto> from(List<Manager> BlacklistedManagerList){
         return BlacklistedManagerList.stream()
                 .map(m -> new BlackListedManagerResponseDto(
                         m.getUuid(),

--- a/common/src/main/java/kernel/maidlab/common/dto/consumer/response/ConsumerProfileResponseDto.java
+++ b/common/src/main/java/kernel/maidlab/common/dto/consumer/response/ConsumerProfileResponseDto.java
@@ -22,7 +22,7 @@ public class ConsumerProfileResponseDto {
     private String address;
     private String detailAddress;
 
-    public static ConsumerProfileResponseDto getInstance(Consumer consumer){
+    public static ConsumerProfileResponseDto from(Consumer consumer){
 
         return new ConsumerProfileResponseDto(
                 consumer.getProfileImage(),

--- a/common/src/main/java/kernel/maidlab/common/dto/consumer/response/LikedManagerResponseDto.java
+++ b/common/src/main/java/kernel/maidlab/common/dto/consumer/response/LikedManagerResponseDto.java
@@ -20,7 +20,7 @@ public class LikedManagerResponseDto {
     private String introduceText;
     private List<Region> region;
 
-    public static List<LikedManagerResponseDto> getLikedManagerResponseDtoList(List<Manager> likedManagerList){
+    public static List<LikedManagerResponseDto> from(List<Manager> likedManagerList){
 
         return likedManagerList.stream()
                 .map(m -> new LikedManagerResponseDto(

--- a/common/src/main/java/kernel/maidlab/common/entity/consumer/Consumer.java
+++ b/common/src/main/java/kernel/maidlab/common/entity/consumer/Consumer.java
@@ -122,10 +122,10 @@ public class Consumer extends TimeBase {
 		this.totalReviewedCnt += 1;
 	}
 
-	public void createProfile(String profileImage, String address, String detailAddress){
-		this.profileImage = profileImage;
-		this.address = address;
-		this.detailAddress = detailAddress;
+	public void createProfile(ConsumerProfileRequestDto consumerProfileRequestDto){
+		this.profileImage = consumerProfileRequestDto.getProfileImage();
+		this.address = consumerProfileRequestDto.getAddress();
+		this.detailAddress = consumerProfileRequestDto.getDetailAddress();
 	}
 
 	public void updateProfile(ConsumerProfileUpdateRequestDto consumerProfileUpdateRequestDto){


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#199 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- Consumer response 객체  정적 팩토리 메서드명 frorm으로 통일
- ConsumerService, ConsumerServiceImpl : 인터페이스와 구현체 분리

### 스크린샷 (선택)




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
