### PR TITLE
Hotfix/be/#238 알림 조회 api 추가 / 매니저 매칭 기준 수정

### DIFF
--- a/api/src/main/java/kernel/maidlab/api/manager/repository/ManagerRepositoryCustomImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/manager/repository/ManagerRepositoryCustomImpl.java
@@ -53,7 +53,9 @@ public class ManagerRepositoryCustomImpl implements ManagerRepositoryCustom {
 				manager.isVerified.eq(Status.APPROVED), manager.isDeleted.isFalse(), manager.id.notIn(
 					JPAExpressions.select(reservation.managerId)
 						.from(reservation)
-						.where(reservation.managerId.isNotNull(), reservation.status.eq(Status.APPROVED),
+						.where(reservation.managerId.isNotNull(),
+							reservation.status.eq(Status.MATCHED)
+								.or(reservation.status.eq(Status.PAID).or(reservation.status.eq(Status.WORKING))),
 							reservation.startTime.lt(end),     // 예약 시작 < 요청 종료
 							reservation.endTime.gt(start)      // 예약 종료 > 요청 시작
 						)))

--- a/api/src/main/java/kernel/maidlab/api/notification/controller/NotificationController.java
+++ b/api/src/main/java/kernel/maidlab/api/notification/controller/NotificationController.java
@@ -2,6 +2,9 @@ package kernel.maidlab.api.notification.controller;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -9,6 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -57,6 +61,17 @@ public class NotificationController {
 	@GetMapping("/unread")
 	public ResponseEntity<ResponseDto<List<NotificationDto>>> getUnreadNotifications(HttpServletRequest request) {
 		List<NotificationDto> notifications = notificationService.getUnreadNotifications(request);
+		return ResponseDto.success(ResponseType.SUCCESS, notifications);
+	}
+
+	@Operation(summary = "전체 알림 조회", description = "사용자의 모든 알림 목록을 페이징으로 조회합니다.")
+	@GetMapping
+	public ResponseEntity<ResponseDto<Page<NotificationDto>>> getAllNotifications(
+		HttpServletRequest request,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size) {
+		Pageable pageable = PageRequest.of(page, size);
+		Page<NotificationDto> notifications = notificationService.getAllNotifications(request, pageable);
 		return ResponseDto.success(ResponseType.SUCCESS, notifications);
 	}
 

--- a/api/src/main/java/kernel/maidlab/api/notification/service/NotificationService.java
+++ b/api/src/main/java/kernel/maidlab/api/notification/service/NotificationService.java
@@ -23,6 +23,8 @@ public interface NotificationService {
 	// 알림 조회
 	List<NotificationDto> getUnreadNotifications(HttpServletRequest request);
 
+	Page<NotificationDto> getAllNotifications(HttpServletRequest request, Pageable pageable);
+
 	Page<NotificationDto> getNotifications(HttpServletRequest request, Pageable pageable);
 
 	List<NotificationDto> getNotificationsByType(HttpServletRequest request, NotificationType type);

--- a/api/src/main/java/kernel/maidlab/api/notification/service/NotificationServiceImpl.java
+++ b/api/src/main/java/kernel/maidlab/api/notification/service/NotificationServiceImpl.java
@@ -197,6 +197,14 @@ public class NotificationServiceImpl implements NotificationService {
 	}
 
 	@Override
+	public Page<NotificationDto> getAllNotifications(HttpServletRequest request, Pageable pageable) {
+		Long id = getCurrentUserId(request);
+		UserType type = getCurrentUserType(request);
+		return notificationRepository.findByReceiverIdAndReceiverTypeOrderByCreatedAtDesc(id, type, pageable)
+			.map(NotificationDto::fromEntity);
+	}
+
+	@Override
 	public Page<NotificationDto> getNotifications(HttpServletRequest request, Pageable pageable) {
 		Long id = getCurrentUserId(request);
 		UserType type = getCurrentUserType(request);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#238 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

매칭 기준을 분명 수정했는데 깃으로 푸시를 안했던가 뭔가 덮혔던가 둘 중 하나 였던 것 같음

계정별로 수신된 알림 전체 조회하는 api 추가 

sse반응 속도는 프록시 유지시간 늘리니까 바로 증가됨

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

this close #238 